### PR TITLE
ci: use github instead of git

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - 'release/**'
+      - 'next'
 
 permissions:
   contents: write  # For creating releases and updating changelog
@@ -13,7 +14,7 @@ permissions:
 
 jobs:
   cd:
-    concurrency: ci-${{ github.ref }}
+    concurrency: cd-${{ github.ref }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - 'release/**'
+      - 'next'
       - 'beta'
       - 'alpha'
       - 'rc'

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -18,6 +18,7 @@ on:
         default: 'beta'
         type: choice
         options:
+          - next
           - alpha
           - beta
           - rc

--- a/.releaserc
+++ b/.releaserc
@@ -38,7 +38,6 @@
         "pkgRoot": "dist/ngx-vest-forms"
       }
     ],
-    "@semantic-release/git",
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
add 'next' branch support to CI, CD, and prerelease workflows; remove unused git plugin from release config