### PR TITLE
feat: upgrade dependencies to Angular 21.1

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,4 @@
-# Required because Storybook 10.0.8 and jest-preset-angular 15.0.3 don't support Angular 21 yet
+# Required because Storybook 10.1.11 doesn't support Angular 21 yet
 # Storybook angular peer deps: ">=18.0.0 < 21.0.0"
-# jest-preset-angular peer deps: ">=18.0.0 <21.0.0"
-# Remove this when upgrading to Storybook 11+ or jest-preset-angular 16+
+# Remove this when upgrading to Storybook 11+
 legacy-peer-deps=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,9 @@
         "typescript-eslint": "8.53.0",
         "vitest": "^4.0.17",
         "wait-on": "~9.0.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "ngx-vest-forms",
   "version": "0.0.0-development",
   "license": "MIT",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "ng": "ng",
     "start": "ng serve",


### PR DESCRIPTION
- Bump versions for @analogjs/vite-plugin-angular and @analogjs/vitest-angular to ^2.2.2
- Upgrade @chromatic-com/storybook to ~5.0.0
- Update commitlint packages to ~20.3.1
- Upgrade @storybook/addon-docs, @storybook/addon-links, and @storybook/angular to 10.1.11
- Bump @testing-library/angular to ~19.0.0
- Update vitest packages to ^4.0.17 and eslint-plugin to ~1.6.6
- Upgrade eslint-plugin-prettier to ~5.5.5 and eslint-plugin-storybook to ~10.1.11
- Update jsdom to ^27.4.0 and prettier to ~3.8.0
- Bump typescript-eslint to 8.53.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Require Node >= 22.
  * Updated Angular framework and toolchain to 21.1.0.
  * Upgraded Storybook (10.1.11) and assorted testing, linting, formatting, and build tooling to newer versions.
  * Simplified npm configuration comments related to Storybook guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->