### PR TITLE
fix(state-sync): correct linkedSignal/debounce/late-attach/mode bugs …

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -37,7 +37,6 @@
   ],
   "plugins": [
     "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
     [
       "@semantic-release/npm",
       {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## Unreleased
-
-- fix: update `fastDeepEqual` to use visited object-pair cycle detection, remove the depth cap, and document `Map`/`Set` reference-only semantics alongside structural `Date`/`RegExp` comparisons
-- fix(form-directive): `formState().value` now returns `null` after all controls are dynamically removed instead of returning the previous `linkedSignal` snapshot. Prevents ghost data after group teardown.
-- fix(form-control-state): retry `NgModel.control` attachment once via `afterNextRender` when it is undefined on the first effect run, then dispose. Fixes stale state when the directive renders before NgModel registers (no permanent polling).
-- fix(validate-root-form): `ngxValidateRootFormMode` and `validateRootFormMode` now default to `undefined`. Mode resolution is `ngx ?? legacy ?? 'submit'` so the documented `ngx`-prefix precedence is finally observable when both attributes are explicitly set. **Behavior change is observable only when both attributes are set on the same form** — neither attribute alone changes behavior versus prior versions.
-- feat(pending-state): `createDebouncedPendingState` now accepts either a static `DebouncedPendingStateOptions` object or a `Signal<DebouncedPendingStateOptions>`. Passing a signal makes the debounce timings reactive — `<ngx-form-group-wrapper [pendingDebounce]>` now reflects runtime input changes. Static-object callers are unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## Unreleased
 
 - fix: update `fastDeepEqual` to use visited object-pair cycle detection, remove the depth cap, and document `Map`/`Set` reference-only semantics alongside structural `Date`/`RegExp` comparisons
+- fix(form-directive): `formState().value` now returns `null` after all controls are dynamically removed instead of returning the previous `linkedSignal` snapshot. Prevents ghost data after group teardown.
+- fix(form-control-state): retry `NgModel.control` attachment once via `afterNextRender` when it is undefined on the first effect run, then dispose. Fixes stale state when the directive renders before NgModel registers (no permanent polling).
+- fix(validate-root-form): `ngxValidateRootFormMode` and `validateRootFormMode` now default to `undefined`. Mode resolution is `ngx ?? legacy ?? 'submit'` so the documented `ngx`-prefix precedence is finally observable when both attributes are explicitly set. **Behavior change is observable only when both attributes are set on the same form** — neither attribute alone changes behavior versus prior versions.
+- feat(pending-state): `createDebouncedPendingState` now accepts either a static `DebouncedPendingStateOptions` object or a `Signal<DebouncedPendingStateOptions>`. Passing a signal makes the debounce timings reactive — `<ngx-form-group-wrapper [pendingDebounce]>` now reflects runtime input changes. Static-object callers are unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "@commitlint/cli": "~20.5.3",
         "@commitlint/config-conventional": "~20.5.3",
         "@playwright/test": "1.59.1",
-        "@semantic-release/changelog": "~6.0.3",
         "@semantic-release/git": "~10.0.1",
         "@storybook/addon-coverage": "~3.0.1",
         "@storybook/addon-docs": "10.3.6",
@@ -9290,25 +9289,6 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@semantic-release/changelog": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
-      "integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "lodash": "^4.17.4"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=18.0.0"
-      }
     },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "13.0.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@commitlint/cli": "~20.5.3",
     "@commitlint/config-conventional": "~20.5.3",
     "@playwright/test": "1.59.1",
-    "@semantic-release/changelog": "~6.0.3",
     "@semantic-release/git": "~10.0.1",
     "@storybook/addon-coverage": "~3.0.1",
     "@storybook/addon-docs": "10.3.6",

--- a/projects/ngx-vest-forms/src/lib/components/form-group-wrapper/form-group-wrapper.component.ts
+++ b/projects/ngx-vest-forms/src/lib/components/form-group-wrapper/form-group-wrapper.component.ts
@@ -68,7 +68,7 @@ export class FormGroupWrapperComponent {
 
   private readonly pendingState = createDebouncedPendingState(
     this.errorDisplay.isPending,
-    this.pendingDebounce()
+    this.pendingDebounce
   );
   protected readonly showPendingMessage = this.pendingState.showPendingMessage;
 

--- a/projects/ngx-vest-forms/src/lib/directives/form-control-state.directive.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/form-control-state.directive.ts
@@ -128,6 +128,9 @@ export class FormControlStateDirective {
    * only schedule a single retry — no permanent polling.
    */
   readonly #controlAttachTick = signal(0);
+  // Per-directive-instance latch: not re-armed if #activeControl later
+  // transitions to a different directive. Acceptable because contentChild
+  // resolves stably for a given directive lifetime.
   #controlAttachRetryScheduled = false;
 
   constructor() {

--- a/projects/ngx-vest-forms/src/lib/directives/form-control-state.directive.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/form-control-state.directive.ts
@@ -128,10 +128,11 @@ export class FormControlStateDirective {
    * only schedule a single retry — no permanent polling.
    */
   readonly #controlAttachTick = signal(0);
-  // Per-directive-instance latch: not re-armed if #activeControl later
-  // transitions to a different directive. Acceptable because contentChild
-  // resolves stably for a given directive lifetime.
+  // Latch is scoped to the *current* `#activeControl` instance. When the
+  // active control changes (e.g. host swaps an `@if` block, NgModel
+  // recreates), the latch resets so a fresh late-attach gets one retry.
   #controlAttachRetryScheduled = false;
+  #lastSeenActiveControl: AbstractControlDirective | null = null;
 
   constructor() {
     // Update control state reactively with proper cleanup
@@ -141,6 +142,15 @@ export class FormControlStateDirective {
       // Track the retry tick so a late-attached `control.control` re-runs this
       // effect after the next render.
       this.#controlAttachTick();
+
+      // Re-arm the late-attach latch whenever the active control identity
+      // changes — including transitions to/from null — so a newly mounted
+      // directive whose `FormControl` registers asynchronously gets its own
+      // single retry.
+      if (control !== this.#lastSeenActiveControl) {
+        this.#lastSeenActiveControl = control;
+        this.#controlAttachRetryScheduled = false;
+      }
 
       if (!control) {
         this.#controlStateSignal.set(INITIAL_FORM_CONTROL_STATE);

--- a/projects/ngx-vest-forms/src/lib/directives/form-control-state.directive.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/form-control-state.directive.ts
@@ -2,6 +2,7 @@ import {
   Directive,
   Injector,
   afterEveryRender,
+  afterNextRender,
   computed,
   contentChild,
   effect,
@@ -119,14 +120,42 @@ export class FormControlStateDirective {
     INITIAL_FORM_CONTROL_STATE
   );
 
+  /**
+   * Tick bumped once via `afterNextRender` if `control.control` is undefined
+   * at the first effect run (NgModel registers asynchronously). Reading this
+   * signal inside the effect causes a re-evaluation after the next render so
+   * we pick up the late-attached `FormControl`. Bookkeeping below ensures we
+   * only schedule a single retry — no permanent polling.
+   */
+  readonly #controlAttachTick = signal(0);
+  #controlAttachRetryScheduled = false;
+
   constructor() {
     // Update control state reactively with proper cleanup
     effect((onCleanup) => {
       const control = this.#activeControl();
       const interaction = this.#interactionState();
+      // Track the retry tick so a late-attached `control.control` re-runs this
+      // effect after the next render.
+      this.#controlAttachTick();
 
       if (!control) {
         this.#controlStateSignal.set(INITIAL_FORM_CONTROL_STATE);
+        return;
+      }
+
+      // NgModel attaches its `FormControl` during its own ngOnInit, which can
+      // run after this effect's first execution in some host orderings. If
+      // `control.control` isn't there yet, schedule a single `afterNextRender`
+      // retry so we re-evaluate once Angular finishes wiring directives.
+      if (!control.control && !this.#controlAttachRetryScheduled) {
+        this.#controlAttachRetryScheduled = true;
+        afterNextRender(
+          () => {
+            this.#controlAttachTick.update((v) => v + 1);
+          },
+          { injector: this.#injector }
+        );
         return;
       }
 

--- a/projects/ngx-vest-forms/src/lib/directives/form.directive.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/form.directive.ts
@@ -202,8 +202,6 @@ export class FormDirective<T extends Record<string, unknown>> {
    */
   #destroyed = false;
 
-  // Track last linked value to prevent unnecessary updates
-  #lastLinkedValue: T | null = null;
   #lastSyncedFormValue: T | null = null;
   #lastSyncedModelValue: T | null = null;
 
@@ -229,14 +227,12 @@ export class FormDirective<T extends Record<string, unknown>> {
   readonly #formValueSignal = linkedSignal(() => {
     // Track changes that affect the merged form snapshot.
     this.#formSnapshotTick();
-    const raw = mergeValuesAndRawValues<T>(this.ngForm.form);
-    if (Object.keys(this.ngForm.form.controls).length > 0) {
-      this.#lastLinkedValue = raw;
-      return raw;
-    } else if (this.#lastLinkedValue !== null) {
-      return this.#lastLinkedValue;
+    if (Object.keys(this.ngForm.form.controls).length === 0) {
+      // No controls remain (e.g. dynamic group removal): expose `null` so
+      // consumers don't see ghost data from a previous form shape.
+      return null;
     }
-    return null;
+    return mergeValuesAndRawValues<T>(this.ngForm.form);
   });
 
   /**
@@ -999,7 +995,6 @@ export class FormDirective<T extends Record<string, unknown>> {
     // is treated as a model change (not a conflict with stale form values)
     this.#lastSyncedFormValue = null;
     this.#lastSyncedModelValue = null;
-    this.#lastLinkedValue = null;
 
     // Force change detection to ensure DOM updates are reflected
     // Note: This is still needed even with signals because we're modifying NgForm

--- a/projects/ngx-vest-forms/src/lib/directives/state-sync-correctness.spec.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/state-sync-correctness.spec.ts
@@ -1,28 +1,22 @@
 /* eslint-disable @angular-eslint/component-selector */
-import { Component, signal, viewChild } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { Component, signal, viewChild, type WritableSignal } from '@angular/core';
 import { render, screen, waitFor } from '@testing-library/angular';
 import { enforce, only, staticSuite, test as vestTest } from 'vest';
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ROOT_FORM } from '../constants';
 import { NgxVestForms } from '../exports';
-import { createDebouncedPendingState } from '../utils/pending-state.utils';
 import { FormDirective } from './form.directive';
 
 /**
  * Acceptance tests for issue #106 — "State-sync correctness" bundle:
  *   1. `formState().value` resets to `null` when all controls are dynamically removed.
- *   2. `[pendingDebounce]` reflects runtime input changes on `<ngx-form-group-wrapper>`.
- *   3. `form-control-state` tracks late-attached `NgModel.control`.
- *   4. `ngxValidateRootFormMode` precedence is `ngx ?? legacy ?? 'submit'`
+ *   2. `form-control-state` tracks late-attached `NgModel.control`.
+ *   3. `ngxValidateRootFormMode` precedence is `ngx ?? legacy ?? 'submit'`
  *      across all four default-vs-explicit combinations.
+ *
+ * Reactive `[pendingDebounce]` propagation is covered as unit tests in
+ * `../utils/pending-state.utils.spec.ts` (the wrapper just forwards the
+ * signal to `createDebouncedPendingState`).
  */
 
 describe('Issue #106 — state-sync correctness', () => {
@@ -79,81 +73,22 @@ describe('Issue #106 — state-sync correctness', () => {
     });
   });
 
-  describe('[pendingDebounce] propagates runtime changes', () => {
-    // Direct unit test against `createDebouncedPendingState` with fake timers.
-    // This is what the wrapper passes its `input()` accessor into, so proving
-    // the function honors a `Signal<DebouncedPendingStateOptions>` proves the
-    // wrapper does too (the wrapper just forwards the signal — TypeScript +
-    // the `pending-state.utils` API surface are the contract).
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('honors a Signal<DebouncedPendingStateOptions> at runtime (showAfter changes propagate)', async () => {
-      await TestBed.runInInjectionContext(async () => {
-        const isPending = signal(false);
-        const opts = signal({ showAfter: 100, minimumDisplay: 50 });
-        const result = createDebouncedPendingState(isPending, opts);
-
-        // Bump the debounce BEFORE pending starts. A static-options
-        // implementation would have captured 100ms at construction time and
-        // ignored the change.
-        opts.set({ showAfter: 1500, minimumDisplay: 50 });
-        await vi.advanceTimersByTimeAsync(0); // flush effects
-
-        isPending.set(true);
-        await vi.advanceTimersByTimeAsync(0); // flush effects
-
-        // Old 100ms threshold has long passed; new 1500ms hasn't.
-        await vi.advanceTimersByTimeAsync(400);
-        expect(result.showPendingMessage()).toBe(false);
-
-        // Past the new threshold → message must now be visible.
-        await vi.advanceTimersByTimeAsync(1200);
-        expect(result.showPendingMessage()).toBe(true);
-      });
-    });
-
-    it('honors a runtime change DURING a pending cycle', async () => {
-      await TestBed.runInInjectionContext(async () => {
-        const isPending = signal(false);
-        const opts = signal({ showAfter: 100, minimumDisplay: 50 });
-        const result = createDebouncedPendingState(isPending, opts);
-
-        // Start with the short threshold.
-        isPending.set(true);
-        await vi.advanceTimersByTimeAsync(50); // partway to original 100ms
-        expect(result.showPendingMessage()).toBe(false);
-
-        // Update options mid-flight to a much larger threshold. The effect
-        // must restart the timer with the new value, NOT honor the original.
-        opts.set({ showAfter: 1000, minimumDisplay: 50 });
-        await vi.advanceTimersByTimeAsync(0); // flush effects
-
-        // Crossing the original 100ms threshold is no longer enough.
-        await vi.advanceTimersByTimeAsync(100);
-        expect(result.showPendingMessage()).toBe(false);
-
-        // Cross the new 1000ms threshold (timer was restarted on options
-        // change, so we need a full 1000ms from that restart point).
-        await vi.advanceTimersByTimeAsync(1000);
-        expect(result.showPendingMessage()).toBe(true);
-      });
-    });
-  });
-
   describe('form-control-state tracks late-attached NgModel.control', () => {
+    // Uses the documented one-way binding pattern (`[ngModel]` driven by a
+    // signal, updates flow through `(formValueChange)`) so this test
+    // doubles as a faithful usage example, not just a regression assertion.
     @Component({
       selector: 'test-late-attach-host',
       imports: [NgxVestForms],
       template: `
-        <form ngxVestForm>
+        <form
+          ngxVestForm
+          [formValue]="formValue()"
+          (formValueChange)="formValue.set($event)"
+        >
           @if (showInput()) {
             <div formControlState #state="formControlState">
-              <input name="email" [(ngModel)]="email" required />
+              <input name="email" [ngModel]="formValue().email" required />
               <span data-testid="is-invalid">{{ state.isInvalid() }}</span>
               <span data-testid="error-count">{{
                 state.errorMessages().length
@@ -165,7 +100,7 @@ describe('Issue #106 — state-sync correctness', () => {
     })
     class HostComponent {
       readonly showInput = signal(false);
-      email = '';
+      readonly formValue = signal<{ email?: string }>({ email: '' });
     }
 
     it('reflects the control state once NgModel registers asynchronously', async () => {
@@ -233,7 +168,7 @@ describe('Issue #106 — state-sync correctness', () => {
     }
 
     it('combo 1 — neither attribute set → effective default is "submit" (no live error)', async () => {
-      await makeMisMatchedForm(`
+      const { fixture } = await makeMisMatchedForm(`
         <form
           ngxVestForm
           ngxValidateRootForm
@@ -250,8 +185,18 @@ describe('Issue #106 — state-sync correctness', () => {
         </form>
       `);
 
-      // Give the suite a chance to run; in submit mode the error must NOT be present.
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      // Drive the form through a value change. In `live` mode this would
+      // fire the suite and surface the mismatch error; in `submit` mode it
+      // must stay silent. Awaiting stability twice (once for the value
+      // change, once for any reactive cascade) is deterministic and
+      // strictly faster than a fixed-duration setTimeout.
+      const host = fixture.componentInstance as { model: WritableSignal<Record<string, unknown>> };
+      host.model.update((m) => ({ ...m, confirmPassword: 'still-mismatched' }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
       expect(screen.queryByTestId('root-error')).not.toBeInTheDocument();
     });
 
@@ -310,7 +255,7 @@ describe('Issue #106 — state-sync correctness', () => {
     });
 
     it('combo 4 — both set → ngx-prefixed input takes precedence over legacy', async () => {
-      await makeMisMatchedForm(`
+      const { fixture } = await makeMisMatchedForm(`
         <form
           ngxVestForm
           ngxValidateRootForm
@@ -329,8 +274,15 @@ describe('Issue #106 — state-sync correctness', () => {
         </form>
       `);
 
-      // ngx says 'submit' → no error before submit even though legacy says 'live'.
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      // Trigger a value change that *would* fire validation if the legacy
+      // 'live' mode were honored. ngx says 'submit', so it must stay silent.
+      const host = fixture.componentInstance as { model: WritableSignal<Record<string, unknown>> };
+      host.model.update((m) => ({ ...m, confirmPassword: 'still-mismatched' }));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
       expect(screen.queryByTestId('root-error')).not.toBeInTheDocument();
     });
   });

--- a/projects/ngx-vest-forms/src/lib/directives/state-sync-correctness.spec.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/state-sync-correctness.spec.ts
@@ -1,10 +1,19 @@
 /* eslint-disable @angular-eslint/component-selector */
 import { Component, signal, viewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { render, screen, waitFor } from '@testing-library/angular';
 import { enforce, only, staticSuite, test as vestTest } from 'vest';
-import { describe, expect, it } from 'vitest';
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from 'vitest';
 import { ROOT_FORM } from '../constants';
 import { NgxVestForms } from '../exports';
+import { createDebouncedPendingState } from '../utils/pending-state.utils';
 import { FormDirective } from './form.directive';
 
 /**
@@ -71,67 +80,68 @@ describe('Issue #106 — state-sync correctness', () => {
   });
 
   describe('[pendingDebounce] propagates runtime changes', () => {
-    @Component({
-      selector: 'test-pending-debounce-host',
-      imports: [NgxVestForms],
-      template: `
-        <form
-          ngxVestForm
-          [suite]="suite"
-          [formValue]="formValue()"
-          (formValueChange)="formValue.set($event)"
-        >
-          <ngx-form-group-wrapper
-            ngModelGroup="profile"
-            [pendingDebounce]="pendingDebounce()"
-          >
-            <input name="email" [ngModel]="formValue().profile?.email" />
-          </ngx-form-group-wrapper>
-        </form>
-      `,
-    })
-    class HostComponent {
-      readonly formValue = signal<{ profile?: { email?: string } }>({
-        profile: { email: '' },
+    // Direct unit test against `createDebouncedPendingState` with fake timers.
+    // This is what the wrapper passes its `input()` accessor into, so proving
+    // the function honors a `Signal<DebouncedPendingStateOptions>` proves the
+    // wrapper does too (the wrapper just forwards the signal — TypeScript +
+    // the `pending-state.utils` API surface are the contract).
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('honors a Signal<DebouncedPendingStateOptions> at runtime (showAfter changes propagate)', async () => {
+      await TestBed.runInInjectionContext(async () => {
+        const isPending = signal(false);
+        const opts = signal({ showAfter: 100, minimumDisplay: 50 });
+        const result = createDebouncedPendingState(isPending, opts);
+
+        // Bump the debounce BEFORE pending starts. A static-options
+        // implementation would have captured 100ms at construction time and
+        // ignored the change.
+        opts.set({ showAfter: 1500, minimumDisplay: 50 });
+        await vi.advanceTimersByTimeAsync(0); // flush effects
+
+        isPending.set(true);
+        await vi.advanceTimersByTimeAsync(0); // flush effects
+
+        // Old 100ms threshold has long passed; new 1500ms hasn't.
+        await vi.advanceTimersByTimeAsync(400);
+        expect(result.showPendingMessage()).toBe(false);
+
+        // Past the new threshold → message must now be visible.
+        await vi.advanceTimersByTimeAsync(1200);
+        expect(result.showPendingMessage()).toBe(true);
       });
-      readonly pendingDebounce = signal({
-        showAfter: 100,
-        minimumDisplay: 50,
+    });
+
+    it('honors a runtime change DURING a pending cycle', async () => {
+      await TestBed.runInInjectionContext(async () => {
+        const isPending = signal(false);
+        const opts = signal({ showAfter: 100, minimumDisplay: 50 });
+        const result = createDebouncedPendingState(isPending, opts);
+
+        // Start with the short threshold.
+        isPending.set(true);
+        await vi.advanceTimersByTimeAsync(50); // partway to original 100ms
+        expect(result.showPendingMessage()).toBe(false);
+
+        // Update options mid-flight to a much larger threshold. The effect
+        // must restart the timer with the new value, NOT honor the original.
+        opts.set({ showAfter: 1000, minimumDisplay: 50 });
+        await vi.advanceTimersByTimeAsync(0); // flush effects
+
+        // Crossing the original 100ms threshold is no longer enough.
+        await vi.advanceTimersByTimeAsync(100);
+        expect(result.showPendingMessage()).toBe(false);
+
+        // Cross the new 1000ms threshold (timer was restarted on options
+        // change, so we need a full 1000ms from that restart point).
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(result.showPendingMessage()).toBe(true);
       });
-      readonly suite = staticSuite(
-        (
-          model: { profile?: { email?: string } } = {},
-          field?: string
-        ) => {
-          only(field);
-          vestTest('profile.email', 'Email is required', () => {
-            enforce(model.profile?.email ?? '').isNotBlank();
-          });
-        }
-      );
-    }
-
-    it('updates the showAfter timing when the input changes at runtime', async () => {
-      const { fixture } = await render(HostComponent);
-      const host = fixture.componentInstance;
-
-      // Bump the debounce so a fresh validation cycle waits 1500ms before
-      // marking the pending message as visible. With the bug, the original
-      // 100ms value is still in effect.
-      host.pendingDebounce.set({ showAfter: 1500, minimumDisplay: 50 });
-      fixture.detectChanges();
-
-      // Wait long enough for the *old* showAfter (100ms) to expire while still
-      // below the *new* one (1500ms). The form has just rendered and validation
-      // is pending, so a stale config would have already shown the message.
-      await new Promise((resolve) => setTimeout(resolve, 400));
-      fixture.detectChanges();
-
-      const wrapper = fixture.nativeElement.querySelector(
-        'ngx-form-group-wrapper'
-      ) as HTMLElement | null;
-      expect(wrapper).toBeTruthy();
-      expect(wrapper?.getAttribute('aria-busy')).not.toBe('true');
     });
   });
 
@@ -170,7 +180,8 @@ describe('Issue #106 — state-sync correctness', () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      // Required input starts as invalid; the directive must reflect that.
+      // Required input starts as invalid; the directive must reflect that
+      // AND surface the validator error rather than just flipping isInvalid.
       const isInvalidEl = await waitFor(() => {
         const el = fixture.nativeElement.querySelector(
           '[data-testid="is-invalid"]'
@@ -179,6 +190,16 @@ describe('Issue #106 — state-sync correctness', () => {
         return el as HTMLElement;
       });
       expect(isInvalidEl.textContent).toBe('true');
+
+      // Positive proof the late-attach retry actually wired up the
+      // FormControl: the `required` validator's error must surface via the
+      // directive's exposed `errorMessages()` signal. Without the retry the
+      // status subscription never attaches and this count stays 0.
+      const errorCountEl = fixture.nativeElement.querySelector(
+        '[data-testid="error-count"]'
+      ) as HTMLElement | null;
+      expect(errorCountEl).toBeTruthy();
+      expect(Number(errorCountEl?.textContent)).toBeGreaterThan(0);
     });
   });
 

--- a/projects/ngx-vest-forms/src/lib/directives/state-sync-correctness.spec.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/state-sync-correctness.spec.ts
@@ -1,0 +1,316 @@
+/* eslint-disable @angular-eslint/component-selector */
+import { Component, signal, viewChild } from '@angular/core';
+import { render, screen, waitFor } from '@testing-library/angular';
+import { enforce, only, staticSuite, test as vestTest } from 'vest';
+import { describe, expect, it } from 'vitest';
+import { ROOT_FORM } from '../constants';
+import { NgxVestForms } from '../exports';
+import { FormDirective } from './form.directive';
+
+/**
+ * Acceptance tests for issue #106 — "State-sync correctness" bundle:
+ *   1. `formState().value` resets to `null` when all controls are dynamically removed.
+ *   2. `[pendingDebounce]` reflects runtime input changes on `<ngx-form-group-wrapper>`.
+ *   3. `form-control-state` tracks late-attached `NgModel.control`.
+ *   4. `ngxValidateRootFormMode` precedence is `ngx ?? legacy ?? 'submit'`
+ *      across all four default-vs-explicit combinations.
+ */
+
+describe('Issue #106 — state-sync correctness', () => {
+  describe('formState().value resets when all controls are removed', () => {
+    @Component({
+      selector: 'test-empty-controls',
+      imports: [NgxVestForms],
+      template: `
+        <form
+          ngxVestForm
+          [formValue]="formValue()"
+          (formValueChange)="formValue.set($event)"
+          #vest="ngxVestForm"
+        >
+          @if (showFields()) {
+            <input name="firstName" [ngModel]="formValue().firstName" />
+            <input name="lastName" [ngModel]="formValue().lastName" />
+          }
+        </form>
+      `,
+    })
+    class HostComponent {
+      readonly formValue = signal<{
+        firstName?: string;
+        lastName?: string;
+      }>({ firstName: 'Ada', lastName: 'Lovelace' });
+      readonly showFields = signal(true);
+      readonly vestForm =
+        viewChild.required<
+          FormDirective<{ firstName?: string; lastName?: string }>
+        >('vest');
+    }
+
+    it('clears the linkedSignal cache and exposes value=null after removal', async () => {
+      const { fixture } = await render(HostComponent);
+      const host = fixture.componentInstance;
+
+      await fixture.whenStable();
+      fixture.detectChanges();
+      // Sanity: form has data while controls are present.
+      expect(host.vestForm().formState().value).toEqual({
+        firstName: 'Ada',
+        lastName: 'Lovelace',
+      });
+
+      // Drop all controls dynamically — the bug previously had `formState().value`
+      // keep returning the last `linkedSignal` snapshot.
+      host.showFields.set(false);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(host.vestForm().formState().value).toBeNull();
+    });
+  });
+
+  describe('[pendingDebounce] propagates runtime changes', () => {
+    @Component({
+      selector: 'test-pending-debounce-host',
+      imports: [NgxVestForms],
+      template: `
+        <form
+          ngxVestForm
+          [suite]="suite"
+          [formValue]="formValue()"
+          (formValueChange)="formValue.set($event)"
+        >
+          <ngx-form-group-wrapper
+            ngModelGroup="profile"
+            [pendingDebounce]="pendingDebounce()"
+          >
+            <input name="email" [ngModel]="formValue().profile?.email" />
+          </ngx-form-group-wrapper>
+        </form>
+      `,
+    })
+    class HostComponent {
+      readonly formValue = signal<{ profile?: { email?: string } }>({
+        profile: { email: '' },
+      });
+      readonly pendingDebounce = signal({
+        showAfter: 100,
+        minimumDisplay: 50,
+      });
+      readonly suite = staticSuite(
+        (
+          model: { profile?: { email?: string } } = {},
+          field?: string
+        ) => {
+          only(field);
+          vestTest('profile.email', 'Email is required', () => {
+            enforce(model.profile?.email ?? '').isNotBlank();
+          });
+        }
+      );
+    }
+
+    it('updates the showAfter timing when the input changes at runtime', async () => {
+      const { fixture } = await render(HostComponent);
+      const host = fixture.componentInstance;
+
+      // Bump the debounce so a fresh validation cycle waits 1500ms before
+      // marking the pending message as visible. With the bug, the original
+      // 100ms value is still in effect.
+      host.pendingDebounce.set({ showAfter: 1500, minimumDisplay: 50 });
+      fixture.detectChanges();
+
+      // Wait long enough for the *old* showAfter (100ms) to expire while still
+      // below the *new* one (1500ms). The form has just rendered and validation
+      // is pending, so a stale config would have already shown the message.
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      fixture.detectChanges();
+
+      const wrapper = fixture.nativeElement.querySelector(
+        'ngx-form-group-wrapper'
+      ) as HTMLElement | null;
+      expect(wrapper).toBeTruthy();
+      expect(wrapper?.getAttribute('aria-busy')).not.toBe('true');
+    });
+  });
+
+  describe('form-control-state tracks late-attached NgModel.control', () => {
+    @Component({
+      selector: 'test-late-attach-host',
+      imports: [NgxVestForms],
+      template: `
+        <form ngxVestForm>
+          @if (showInput()) {
+            <div formControlState #state="formControlState">
+              <input name="email" [(ngModel)]="email" required />
+              <span data-testid="is-invalid">{{ state.isInvalid() }}</span>
+              <span data-testid="error-count">{{
+                state.errorMessages().length
+              }}</span>
+            </div>
+          }
+        </form>
+      `,
+    })
+    class HostComponent {
+      readonly showInput = signal(false);
+      email = '';
+    }
+
+    it('reflects the control state once NgModel registers asynchronously', async () => {
+      const { fixture } = await render(HostComponent);
+      const host = fixture.componentInstance;
+
+      // Mount the input + directive after the host's first change-detection
+      // cycle so NgModel.control is undefined when the directive's first
+      // effect run executes. The afterNextRender retry must pick it up.
+      host.showInput.set(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      // Required input starts as invalid; the directive must reflect that.
+      const isInvalidEl = await waitFor(() => {
+        const el = fixture.nativeElement.querySelector(
+          '[data-testid="is-invalid"]'
+        );
+        expect(el?.textContent).toBe('true');
+        return el as HTMLElement;
+      });
+      expect(isInvalidEl.textContent).toBe('true');
+    });
+  });
+
+  describe('ngxValidateRootFormMode precedence: ngx ?? legacy ?? "submit"', () => {
+    const suite = staticSuite(
+      (data: Record<string, unknown> = {}, field?: string) => {
+        only(field);
+        vestTest(ROOT_FORM, 'Passwords must match', () => {
+          if (data['password'] && data['confirmPassword']) {
+            enforce(data['confirmPassword']).equals(data['password']);
+          }
+        });
+      }
+    );
+
+    async function makeMisMatchedForm(template: string) {
+      @Component({
+        imports: [NgxVestForms],
+        template,
+      })
+      class TestComponent {
+        ROOT_FORM = ROOT_FORM;
+        model = signal<Record<string, unknown>>({
+          password: 'password123',
+          confirmPassword: 'mismatch',
+        });
+        errors = signal<Record<string, string[]>>({});
+        suite = suite;
+      }
+      return render(TestComponent);
+    }
+
+    it('combo 1 — neither attribute set → effective default is "submit" (no live error)', async () => {
+      await makeMisMatchedForm(`
+        <form
+          ngxVestForm
+          ngxValidateRootForm
+          [suite]="suite"
+          [formValue]="model()"
+          (formValueChange)="model.set($event)"
+          (errorsChange)="errors.set($event)"
+        >
+          <input name="password" [ngModel]="model().password" />
+          <input name="confirmPassword" [ngModel]="model().confirmPassword" />
+          @if (errors()[ROOT_FORM]) {
+            <div data-testid="root-error">{{ errors()[ROOT_FORM][0] }}</div>
+          }
+        </form>
+      `);
+
+      // Give the suite a chance to run; in submit mode the error must NOT be present.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(screen.queryByTestId('root-error')).not.toBeInTheDocument();
+    });
+
+    it('combo 2 — only legacy `validateRootFormMode` set → legacy wins', async () => {
+      await makeMisMatchedForm(`
+        <form
+          ngxVestForm
+          ngxValidateRootForm
+          [validateRootFormMode]="'live'"
+          [suite]="suite"
+          [formValue]="model()"
+          (formValueChange)="model.set($event)"
+          (errorsChange)="errors.set($event)"
+        >
+          <input name="password" [ngModel]="model().password" />
+          <input name="confirmPassword" [ngModel]="model().confirmPassword" />
+          @if (errors()[ROOT_FORM]) {
+            <div data-testid="root-error">{{ errors()[ROOT_FORM][0] }}</div>
+          }
+        </form>
+      `);
+
+      await waitFor(
+        () => {
+          expect(screen.queryByTestId('root-error')).toBeInTheDocument();
+        },
+        { timeout: 2000 }
+      );
+    });
+
+    it('combo 3 — only `ngxValidateRootFormMode` set → ngx wins', async () => {
+      await makeMisMatchedForm(`
+        <form
+          ngxVestForm
+          ngxValidateRootForm
+          [ngxValidateRootFormMode]="'live'"
+          [suite]="suite"
+          [formValue]="model()"
+          (formValueChange)="model.set($event)"
+          (errorsChange)="errors.set($event)"
+        >
+          <input name="password" [ngModel]="model().password" />
+          <input name="confirmPassword" [ngModel]="model().confirmPassword" />
+          @if (errors()[ROOT_FORM]) {
+            <div data-testid="root-error">{{ errors()[ROOT_FORM][0] }}</div>
+          }
+        </form>
+      `);
+
+      await waitFor(
+        () => {
+          expect(screen.queryByTestId('root-error')).toBeInTheDocument();
+        },
+        { timeout: 2000 }
+      );
+    });
+
+    it('combo 4 — both set → ngx-prefixed input takes precedence over legacy', async () => {
+      await makeMisMatchedForm(`
+        <form
+          ngxVestForm
+          ngxValidateRootForm
+          [ngxValidateRootFormMode]="'submit'"
+          [validateRootFormMode]="'live'"
+          [suite]="suite"
+          [formValue]="model()"
+          (formValueChange)="model.set($event)"
+          (errorsChange)="errors.set($event)"
+        >
+          <input name="password" [ngModel]="model().password" />
+          <input name="confirmPassword" [ngModel]="model().confirmPassword" />
+          @if (errors()[ROOT_FORM]) {
+            <div data-testid="root-error">{{ errors()[ROOT_FORM][0] }}</div>
+          }
+        </form>
+      `);
+
+      // ngx says 'submit' → no error before submit even though legacy says 'live'.
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      expect(screen.queryByTestId('root-error')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/projects/ngx-vest-forms/src/lib/directives/validate-root-form.directive.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/validate-root-form.directive.ts
@@ -144,12 +144,20 @@ export class ValidateRootFormDirective<T>
 
   /**
    * Validation mode:
-   * - 'submit' (default): Only validates after form submission
-   * - 'live': Validates on every value change
-   * Accepts both validateRootFormMode and ngxValidateRootFormMode
+   * - `'submit'` (effective default): Only validates after form submission.
+   * - `'live'`: Validates on every value change.
+   *
+   * Both inputs default to `undefined` so we can detect whether the consumer
+   * set them explicitly. Precedence is `ngx ?? legacy ?? 'submit'`, which
+   * matches the documented behavior — observable only when both attributes
+   * are set explicitly on the same form.
    */
-  readonly validateRootFormMode = input<'submit' | 'live'>('submit');
-  readonly ngxValidateRootFormMode = input<'submit' | 'live'>('submit');
+  readonly validateRootFormMode = input<'submit' | 'live' | undefined>(
+    undefined
+  );
+  readonly ngxValidateRootFormMode = input<'submit' | 'live' | undefined>(
+    undefined
+  );
 
   constructor() {
     // Convert signals to Observables in injection context
@@ -233,11 +241,13 @@ export class ValidateRootFormDirective<T>
       return of(null);
     }
 
-    // Get mode from either input (ngx prefix takes precedence if both set)
+    // Mode precedence: ngx-prefixed input wins over legacy input; both default
+    // to `undefined` so the precedence rule is implementable without losing
+    // the legacy attribute when the new one is not set.
     const mode =
-      this.ngxValidateRootFormMode() !== 'submit'
-        ? this.ngxValidateRootFormMode()
-        : this.validateRootFormMode();
+      this.ngxValidateRootFormMode() ??
+      this.validateRootFormMode() ??
+      'submit';
 
     // In 'submit' mode, skip validation until form is submitted
     if (mode === 'submit' && !this.hasSubmitted()) {

--- a/projects/ngx-vest-forms/src/lib/utils/pending-state.utils.spec.ts
+++ b/projects/ngx-vest-forms/src/lib/utils/pending-state.utils.spec.ts
@@ -406,5 +406,59 @@ describe('pending-state.utils', () => {
         await expect(vi.runAllTimersAsync()).resolves.not.toThrow();
       });
     });
+
+    describe('Signal<DebouncedPendingStateOptions> input (runtime-reactive)', () => {
+      // The wrapper component forwards an `input()` accessor as the options
+      // arg, so the function must read those timings reactively rather than
+      // capturing them at construction. Regression coverage for issue #106.
+      it('honors a Signal whose value changes BEFORE pending starts', async () => {
+        await TestBed.runInInjectionContext(async () => {
+          const isPending = signal(false);
+          const opts = signal({ showAfter: 100, minimumDisplay: 50 });
+          const result = createDebouncedPendingState(isPending, opts);
+
+          // Bump the threshold while idle. A static-options implementation
+          // would have captured 100ms at construction time and ignored this.
+          opts.set({ showAfter: 1500, minimumDisplay: 50 });
+          await vi.advanceTimersByTimeAsync(0);
+
+          isPending.set(true);
+          await vi.advanceTimersByTimeAsync(0);
+
+          // Old 100ms has long passed; new 1500ms hasn't.
+          await vi.advanceTimersByTimeAsync(400);
+          expect(result.showPendingMessage()).toBe(false);
+
+          // Past the new threshold → message must now be visible.
+          await vi.advanceTimersByTimeAsync(1200);
+          expect(result.showPendingMessage()).toBe(true);
+        });
+      });
+
+      it('honors a Signal whose value changes DURING a pending cycle', async () => {
+        await TestBed.runInInjectionContext(async () => {
+          const isPending = signal(false);
+          const opts = signal({ showAfter: 100, minimumDisplay: 50 });
+          const result = createDebouncedPendingState(isPending, opts);
+
+          isPending.set(true);
+          await vi.advanceTimersByTimeAsync(50); // partway to original 100ms
+          expect(result.showPendingMessage()).toBe(false);
+
+          // Update options mid-flight; effect must restart the timer with
+          // the new threshold rather than honoring the original.
+          opts.set({ showAfter: 1000, minimumDisplay: 50 });
+          await vi.advanceTimersByTimeAsync(0);
+
+          // Crossing the original 100ms is no longer enough.
+          await vi.advanceTimersByTimeAsync(100);
+          expect(result.showPendingMessage()).toBe(false);
+
+          // Cross the new 1000ms threshold from the restart point.
+          await vi.advanceTimersByTimeAsync(1000);
+          expect(result.showPendingMessage()).toBe(true);
+        });
+      });
+    });
   });
 });

--- a/projects/ngx-vest-forms/src/lib/utils/pending-state.utils.ts
+++ b/projects/ngx-vest-forms/src/lib/utils/pending-state.utils.ts
@@ -1,4 +1,4 @@
-import { effect, Signal, signal } from '@angular/core';
+import { effect, isSignal, Signal, signal } from '@angular/core';
 
 /**
  * Options for configuring debounced pending state behavior.
@@ -18,6 +18,15 @@ export type DebouncedPendingStateOptions = {
    */
   minimumDisplay?: number;
 };
+
+/**
+ * Accepts either a static options object or a reactive `Signal` (e.g. an
+ * `input()` accessor) so consumers can update debounce timings at runtime
+ * without recreating the pending-state machine.
+ */
+export type DebouncedPendingStateOptionsInput =
+  | DebouncedPendingStateOptions
+  | Signal<DebouncedPendingStateOptions>;
 
 /**
  * Result of createDebouncedPendingState containing the debounced signal
@@ -72,9 +81,19 @@ export type DebouncedPendingStateResult = {
  */
 export function createDebouncedPendingState(
   isPending: Signal<boolean>,
-  options: DebouncedPendingStateOptions = {}
+  options: DebouncedPendingStateOptionsInput = {}
 ): DebouncedPendingStateResult {
-  const { showAfter = 200, minimumDisplay = 500 } = options;
+  // Reading the options inside the effect makes the timings reactive: when
+  // a consumer passes an `input()` accessor (a Signal), changes propagate at
+  // runtime rather than getting captured once at construction.
+  const optionsSignal: Signal<DebouncedPendingStateOptions> | null = isSignal(
+    options
+  )
+    ? (options as Signal<DebouncedPendingStateOptions>)
+    : null;
+  const staticOptions: DebouncedPendingStateOptions = optionsSignal
+    ? {}
+    : (options as DebouncedPendingStateOptions);
 
   // Create writable signal for debounced state
   const showPendingMessageSignal = signal(false);
@@ -98,6 +117,9 @@ export function createDebouncedPendingState(
   // Effect to manage debounced pending message display
   effect((onCleanup) => {
     const pending = isPending();
+    const current = optionsSignal ? optionsSignal() : staticOptions;
+    const showAfter = current.showAfter ?? 200;
+    const minimumDisplay = current.minimumDisplay ?? 500;
 
     if (pending) {
       // Clear any existing minimum display timeout

--- a/projects/ngx-vest-forms/src/public-api.ts
+++ b/projects/ngx-vest-forms/src/public-api.ts
@@ -50,6 +50,7 @@ export { setValueAtPath } from './lib/utils/form-utils';
 export { createDebouncedPendingState } from './lib/utils/pending-state.utils';
 export type {
   DebouncedPendingStateOptions,
+  DebouncedPendingStateOptionsInput,
   DebouncedPendingStateResult,
 } from './lib/utils/pending-state.utils';
 export { validateShape } from './lib/utils/shape-validation';


### PR DESCRIPTION
…(#106)

Four directive-level corrections that share a "signal reactivity used incorrectly" root cause:

- form.directive: when controls drop to zero (dynamic group removal), `formState().value` resolves to `null` instead of returning the previous `linkedSignal` snapshot. The unused `#lastLinkedValue` cache field is removed.
- form-group-wrapper: `[pendingDebounce]` is consumed reactively. `createDebouncedPendingState` accepts either `DebouncedPendingStateOptions` or `Signal<DebouncedPendingStateOptions>` so consumers can pass an `input()` accessor and have runtime changes propagate.
- form-control-state.directive: when `control.control` is undefined at the first effect run (NgModel registers asynchronously), retries once via `afterNextRender`, then disposes. No permanent polling.
- validate-root-form.directive: `ngxValidateRootFormMode` and the legacy `validateRootFormMode` default to `undefined`. Mode resolution becomes `ngx ?? legacy ?? 'submit'`. Behavior change is observable only when both attributes are explicitly set on the same form.

Tests: new `state-sync-correctness.spec.ts` covers all four behaviors including the four mode-precedence combinations.

Closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pending-state debounce accepts either a static config or a reactive signal; debounce timings can change at runtime.
  * Public API exposes the reactive debounce options type.

* **Bug Fixes**
  * Form state returns null when all dynamic controls are removed, avoiding ghost data.
  * Late-attaching NgModel controls are retried and handled correctly during initial render.
  * Root-form validation mode resolution clarified with improved defaults.

* **Tests**
  * Added state-sync correctness and reactive pending-state tests.

* **Chores**
  * Removed changelog plugin from release config.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->