### PR TITLE
fix(lint): use ReadonlyArray<T> for non-simple types and drop unused imports

### DIFF
--- a/projects/ngx-vest-forms/src/lib/directives/form.directive.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/form.directive.ts
@@ -23,7 +23,6 @@ import {
 import {
   AbstractControl,
   AsyncValidatorFn,
-  FormArray,
   FormGroup,
   NgForm,
   PristineChangeEvent,
@@ -56,7 +55,6 @@ import type { NgxDeepRequired } from '../utils/deep-required';
 import { scheduleMicrotask, scheduleTimeout } from '../utils/destroy-scheduler';
 import type { ValidationConfigMap } from '../utils/field-path-types';
 import { collectTouchedPaths } from '../utils/collect-touched-paths';
-import { stringifyFieldPath } from '../utils/field-path.utils';
 import {
   DEFAULT_FOCUS_SELECTOR,
   DEFAULT_INVALID_SELECTOR,

--- a/projects/ngx-vest-forms/src/lib/utils/field-path.utils.ts
+++ b/projects/ngx-vest-forms/src/lib/utils/field-path.utils.ts
@@ -118,7 +118,7 @@ export function parseFieldPath(path: string): Array<string | number> {
  * ```
  */
 export function stringifyFieldPath(
-  path: readonly (string | number)[]
+  path: ReadonlyArray<string | number>
 ): string {
   if (!path || path.length === 0) return '';
 


### PR DESCRIPTION
## Summary

Lint regression on \`release/v3\` introduced by #145. CI is currently red on every open PR rebased onto this branch.

- Replace \`readonly (string | number)[]\` with \`ReadonlyArray<string | number>\` on \`stringifyFieldPath\`'s path parameter. The project's \`@typescript-eslint/array-type\` rule forbids \`readonly T[]\` for non-simple types (unions/intersections/conditional types), so the union path-segment type must use the \`ReadonlyArray<T>\` long form.
- Drop the \`FormArray\` and \`stringifyFieldPath\` imports from \`form.directive.ts\`; both became unused after \`collectTouchedPaths\` was extracted to its own module.

## Test plan

- [x] \`npm run lint\` (0 errors; 1 pre-existing non-null-assertion warning in \`field-path-resolver.ts\`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)