### PR TITLE
chore: define branch policy and v3-snapshot release config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,26 @@ When generating code for this repository:
 4. Use the umbrella `ngx-vest-forms` skill and its nested workflow sub-skills for feature workflows instead of restating library docs from memory.
 5. Prefer patterns already present in the repo over generic framework advice.
 
+## Branch policy (read before opening PRs)
+
+This repo maintains parallel release lines. Pick the right base branch before
+proposing changes.
+
+- **`master`** — current stable v2 maintenance line. Only target master for v2
+  bug fixes, security patches, or repo-wide governance/tooling changes that
+  must apply to the default branch (PR templates, dependabot config,
+  copilot instructions, CI policy). Do not target master for new v3 features
+  or refactors.
+- **`release/v3`** — active v3 development. All v3 features, refactors, test
+  migrations, and v3-specific dependency upgrades target this branch. Merging
+  here does **not** auto-publish; v3 only ships via manual
+  `workflow_dispatch` of `.github/workflows/prerelease.yml` (snapshot
+  prereleases) — never on PR merge.
+- Other `release/*` branches are maintenance-only for their respective majors.
+
+When uncertain, default to `release/v3` and call out the choice in the PR
+description so a reviewer can redirect if needed.
+
 ## Version baseline
 
 - Angular framework packages: `21.2.5`

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+# Dependabot configuration
+#
+# Branch policy:
+# - master is the v2 stable maintenance line. Dependabot security updates
+#   target the default branch automatically (no explicit entry needed).
+# - release/v3 is the active v3 development line. Version updates flow here
+#   so v3 stays current without polluting the v2 maintenance line.
+#
+# Merging Dependabot PRs into release/v3 does NOT publish anything; v3 only
+# ships via manual workflow_dispatch (see .github/workflows/prerelease.yml).
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    target-branch: "release/v3"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - dependencies
+      - "release/v3"
+    commit-message:
+      prefix: build
+      prefix-development: chore
+      include: scope

--- a/.releaserc
+++ b/.releaserc
@@ -8,6 +8,7 @@
     },
     {
       "name": "release/v3",
+      "range": "3.x",
       "prerelease": "v3-snapshot",
       "channel": "v3-snapshot"
     },

--- a/.releaserc
+++ b/.releaserc
@@ -7,6 +7,11 @@
       "channel": "release-v1"
     },
     {
+      "name": "release/v3",
+      "prerelease": "v3-snapshot",
+      "channel": "v3-snapshot"
+    },
+    {
       "name": "next",
       "prerelease": "next"
     },


### PR DESCRIPTION
## Summary

Codifies the v2/v3 branch policy so Dependabot, Copilot SWE Agent, and human contributors stop defaulting to `master` for v3 work. Also fills a gap in `.releaserc` so manual `release/v3` prereleases publish to a named npm dist-tag scoped to the 3.x version line, instead of bumping from the latest v2 tag.

## Changes

- **`.github/dependabot.yml` (new)** — Weekly grouped npm version updates target `release/v3`. `master` keeps Dependabot's default security-only behavior (no entry needed; it's the default branch). Updates flow into v3, and merging them does not publish anything since v3 only ships via manual `workflow_dispatch`.
- **`.github/copilot-instructions.md`** — New "Branch policy" section near the top explaining when to target `master` (v2 maintenance, repo-wide governance) vs `release/v3` (all v3 development) and noting that v3 merges never auto-publish.
- **`.releaserc`** — Adds a `release/v3` entry with `prerelease`/`channel` `v3-snapshot` and `range: "3.x"`. The range scopes prereleases to the v3 major regardless of commit history (mirrors the `release/v1.x` pattern). Without this, manually triggering `prerelease.yml` against `release/v3` would either fall through semantic-release's branch matching or generate `2.x-v3-snapshot.N` versions from the current `v2.7.0` baseline.

## Why now

- PR #154 (Copilot) and PR #151 (Dependabot) both targeted `master` by default even though active development is on `release/v3` — the bots had no signal otherwise.
- The Storybook removal landed on `master` via #153 and had to be ported to v3 separately via #155 (now merged).

This PR eliminates that ambiguity going forward.

## Notes

- This change lives on `master` because GitHub reads `.github/dependabot.yml`, `.github/copilot-instructions.md`, and PR templates from the **default branch** for all PRs regardless of base.
- A parallel update of `copilot-instructions.md` on `release/v3` would also be useful (its content has diverged from master's), but is out of scope here — small follow-up after this merges.

## Test plan

- [ ] CI green
- [ ] After merge, the next Dependabot run opens against `release/v3` (visible at https://github.com/ngx-vest-forms/ngx-vest-forms/network/updates)
- [ ] Spot-check by running `prerelease.yml` (workflow_dispatch) against `release/v3` to confirm semantic-release recognizes the branch and produces a `3.x-v3-snapshot.N` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)