### PR TITLE
feat(form-utils)!: return discriminated union from getAllFormErrors

### DIFF
--- a/docs/migration/MIGRATION-v2.x-to-v3.0.0.md
+++ b/docs/migration/MIGRATION-v2.x-to-v3.0.0.md
@@ -111,7 +111,7 @@ memo(() => {
 }, [model.userId]);
 ```
 
-## `getAllFormErrors` returns a discriminated union
+## `getAllFormErrors` returns `{ errors, warnings }`
 
 v2 returned `Record<string, string[]>` and attached field-level warnings as a non-enumerable `warnings` property on each errors array. That side-channel was invisible to `Object.keys`, spreads, `JSON.stringify`, and `structuredClone`, which made it easy to miss and impossible to serialise.
 

--- a/docs/migration/MIGRATION-v2.x-to-v3.0.0.md
+++ b/docs/migration/MIGRATION-v2.x-to-v3.0.0.md
@@ -111,6 +111,40 @@ memo(() => {
 }, [model.userId]);
 ```
 
+## `getAllFormErrors` returns a discriminated union
+
+v2 returned `Record<string, string[]>` and attached field-level warnings as a non-enumerable `warnings` property on each errors array. That side-channel was invisible to `Object.keys`, spreads, `JSON.stringify`, and `structuredClone`, which made it easy to miss and impossible to serialise.
+
+v3 returns a sibling-record shape so errors and warnings are first-class:
+
+```typescript
+export type NgxFormErrorsByPath = {
+  errors: Record<string, string[]>;
+  warnings: Record<string, string[]>;
+};
+
+export function getAllFormErrors(form?: AbstractControl): NgxFormErrorsByPath;
+```
+
+Before:
+
+```typescript
+const all = getAllFormErrors(form);
+const fieldErrors = all['user.name']; // string[]
+const fieldWarnings = (all['user.name'] as string[] & { warnings?: string[] })
+  .warnings;
+```
+
+After:
+
+```typescript
+const all = getAllFormErrors(form);
+const fieldErrors = all.errors['user.name']; // string[] | undefined
+const fieldWarnings = all.warnings['user.name']; // string[] | undefined
+```
+
+The `errorsChange` output on `FormDirective` still emits `Record<string, string[]>` (the `errors` slice of the new shape), so templates consuming `(errorsChange)="errors.set($event)"` and reading `errors()['field']` continue to work unchanged. For warnings inside templates, prefer the existing `fieldWarnings()` signal on the directive — it is per-field, reactive, and the recommended path for warning display.
+
 ## v3 selector + token removals
 
 v3.0.0 removes the legacy `sc-` selectors, duplicate directive aliases, duplicate root-form inputs, and `SC_ERROR_DISPLAY_MODE_TOKEN`.

--- a/projects/ngx-vest-forms/src/lib/directives/form.directive.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/form.directive.ts
@@ -299,7 +299,7 @@ export class FormDirective<T extends Record<string, unknown>> {
       this.#validationFeedbackTick();
       return {
         valid: this.ngForm.form.valid,
-        errors: getAllFormErrors(this.ngForm.form),
+        errors: getAllFormErrors(this.ngForm.form).errors,
         value: this.#formValueSignal(),
       };
     },
@@ -437,7 +437,7 @@ export class FormDirective<T extends Record<string, unknown>> {
    */
   readonly errorsChange = outputFromObservable(
     this.#validationFeedback$.pipe(
-      map(() => getAllFormErrors(this.ngForm.form)),
+      map(() => getAllFormErrors(this.ngForm.form).errors),
       takeUntilDestroyed(this.#destroyRef)
     )
   );

--- a/projects/ngx-vest-forms/src/lib/directives/validate-root-form.directive.spec.ts
+++ b/projects/ngx-vest-forms/src/lib/directives/validate-root-form.directive.spec.ts
@@ -143,8 +143,8 @@ describe('ValidateRootFormDirective', () => {
       await waitFor(
         () => {
           const allErrors = getAllFormErrors(component.ngForm.control);
-          expect(allErrors[ROOT_FORM]).toBeDefined();
-          expect(allErrors[ROOT_FORM]).toContain('Passwords must match');
+          expect(allErrors.errors[ROOT_FORM]).toBeDefined();
+          expect(allErrors.errors[ROOT_FORM]).toContain('Passwords must match');
         },
         { timeout: 5000 }
       );
@@ -220,8 +220,10 @@ describe('ValidateRootFormDirective', () => {
       await waitFor(
         () => {
           const allErrors = getAllFormErrors(component.ngForm.control);
-          expect(allErrors[ROOT_FORM]).toBeDefined();
-          expect(allErrors[ROOT_FORM]).toContain('Brecht is not 30 anymore');
+          expect(allErrors.errors[ROOT_FORM]).toBeDefined();
+          expect(allErrors.errors[ROOT_FORM]).toContain(
+            'Brecht is not 30 anymore'
+          );
         },
         { timeout: 5000 }
       );
@@ -310,7 +312,7 @@ describe('ValidateRootFormDirective', () => {
       await waitFor(
         () => {
           const allErrors = getAllFormErrors(component.ngForm.control);
-          expect(allErrors[ROOT_FORM]).toBeUndefined();
+          expect(allErrors.errors[ROOT_FORM]).toBeUndefined();
         },
         { timeout: 5000 }
       );

--- a/projects/ngx-vest-forms/src/lib/utils/form-utils.spec.ts
+++ b/projects/ngx-vest-forms/src/lib/utils/form-utils.spec.ts
@@ -9,8 +9,6 @@ import {
   setValueAtPath,
 } from './form-utils';
 
-type ErrorListWithWarnings = string[] & { warnings?: string[] };
-
 describe('getFormControlField function', () => {
   it('should return correct field name for FormControl in root FormGroup', () => {
     const form = new FormGroup({
@@ -582,15 +580,16 @@ describe('setValueAtPath function', () => {
 });
 
 describe('getAllFormErrors', () => {
-  it('should return empty object when form is undefined', () => {
-    expect(getAllFormErrors(undefined)).toEqual({});
+  it('should return empty errors and warnings when form is undefined', () => {
+    expect(getAllFormErrors(undefined)).toEqual({ errors: {}, warnings: {} });
   });
 
   it('should collect root form errors', () => {
     const form = new FormGroup({});
     form.setErrors({ errors: ['Root error'] });
-    const errors = getAllFormErrors(form);
-    expect(errors[ROOT_FORM]).toEqual(['Root error']);
+    const result = getAllFormErrors(form);
+    expect(result.errors[ROOT_FORM]).toEqual(['Root error']);
+    expect(result.warnings).toEqual({});
   });
 
   it('should collect errors from nested FormGroups', () => {
@@ -602,8 +601,8 @@ describe('getAllFormErrors', () => {
       }),
     });
     form.get('user.name')?.updateValueAndValidity();
-    const errors = getAllFormErrors(form);
-    expect(errors['user.name']).toEqual(['Name error']);
+    const result = getAllFormErrors(form);
+    expect(result.errors['user.name']).toEqual(['Name error']);
   });
 
   it('should not collect errors from disabled controls', () => {
@@ -613,11 +612,12 @@ describe('getAllFormErrors', () => {
     const form = new FormGroup({ field: control });
     control.disable();
     control.updateValueAndValidity();
-    const errors = getAllFormErrors(form);
-    expect(errors['field']).toBeUndefined();
+    const result = getAllFormErrors(form);
+    expect(result.errors['field']).toBeUndefined();
+    expect(result.warnings['field']).toBeUndefined();
   });
 
-  it('should collect warnings as non-enumerable property', () => {
+  it('should expose warnings as a sibling record keyed by field path', () => {
     const control = new FormControl('', {
       validators: () => ({
         errors: ['Error'],
@@ -626,12 +626,14 @@ describe('getAllFormErrors', () => {
     });
     const form = new FormGroup({ field: control });
     control.updateValueAndValidity();
-    const errors = getAllFormErrors(form);
-    expect(errors['field']).toEqual(['Error']);
-    expect((errors['field'] as ErrorListWithWarnings).warnings).toEqual([
-      'Warning',
-    ]);
-    expect(Object.keys(errors['field'] ?? {})).not.toContain('warnings');
+    const result = getAllFormErrors(form);
+    expect(result.errors['field']).toEqual(['Error']);
+    expect(result.warnings['field']).toEqual(['Warning']);
+    // No leakage of warnings onto the errors array (regression: old API
+    // attached warnings as a non-enumerable property on the errors array).
+    expect(
+      Object.getOwnPropertyDescriptor(result.errors['field'] ?? [], 'warnings')
+    ).toBeUndefined();
   });
 
   it('should handle controls with only warnings', () => {
@@ -640,11 +642,9 @@ describe('getAllFormErrors', () => {
     });
     const form = new FormGroup({ field: control });
     control.updateValueAndValidity();
-    const errors = getAllFormErrors(form);
-    expect(errors['field']).toEqual([]);
-    expect((errors['field'] as ErrorListWithWarnings).warnings).toEqual([
-      'Warning',
-    ]);
+    const result = getAllFormErrors(form);
+    expect(result.errors['field']).toBeUndefined();
+    expect(result.warnings['field']).toEqual(['Warning']);
   });
 
   it('should collect errors from deeply nested structures', () => {
@@ -659,8 +659,8 @@ describe('getAllFormErrors', () => {
       }),
     });
     deepControl.updateValueAndValidity();
-    const errors = getAllFormErrors(form);
-    expect(errors['level1.level2.level3']).toEqual(['Deep error']);
+    const result = getAllFormErrors(form);
+    expect(result.errors['level1.level2.level3']).toEqual(['Deep error']);
   });
 
   it('should collect errors from controls inside FormArray using numeric path segments', () => {
@@ -675,9 +675,9 @@ describe('getAllFormErrors', () => {
     });
 
     form.updateValueAndValidity();
-    const errors = getAllFormErrors(form);
+    const result = getAllFormErrors(form);
 
-    expect(errors['users[0].name']).toEqual(['Name error']);
+    expect(result.errors['users[0].name']).toEqual(['Name error']);
   });
 
   it('should keep only string values from errors and warnings arrays', () => {
@@ -690,12 +690,10 @@ describe('getAllFormErrors', () => {
     const form = new FormGroup({ field: control });
 
     control.updateValueAndValidity();
-    const errors = getAllFormErrors(form);
+    const result = getAllFormErrors(form);
 
-    expect(errors['field']).toEqual(['Valid error']);
-    expect((errors['field'] as ErrorListWithWarnings).warnings).toEqual([
-      'Valid warning',
-    ]);
+    expect(result.errors['field']).toEqual(['Valid error']);
+    expect(result.warnings['field']).toEqual(['Valid warning']);
   });
 
   it('should skip unsafe prototype keys while merging value and rawValue', () => {

--- a/projects/ngx-vest-forms/src/lib/utils/form-utils.spec.ts
+++ b/projects/ngx-vest-forms/src/lib/utils/form-utils.spec.ts
@@ -592,6 +592,25 @@ describe('getAllFormErrors', () => {
     expect(result.warnings).toEqual({});
   });
 
+  it('should collect root form warnings under ROOT_FORM', () => {
+    const form = new FormGroup({});
+    form.setErrors({
+      errors: ['Root error'],
+      warnings: ['Root warning'],
+    });
+    const result = getAllFormErrors(form);
+    expect(result.errors[ROOT_FORM]).toEqual(['Root error']);
+    expect(result.warnings[ROOT_FORM]).toEqual(['Root warning']);
+  });
+
+  it('should collect root form warnings even when no root errors are present', () => {
+    const form = new FormGroup({});
+    form.setErrors({ warnings: ['Root-only warning'] });
+    const result = getAllFormErrors(form);
+    expect(result.errors[ROOT_FORM]).toBeUndefined();
+    expect(result.warnings[ROOT_FORM]).toEqual(['Root-only warning']);
+  });
+
   it('should collect errors from nested FormGroups', () => {
     const form = new FormGroup({
       user: new FormGroup({

--- a/projects/ngx-vest-forms/src/lib/utils/form-utils.ts
+++ b/projects/ngx-vest-forms/src/lib/utils/form-utils.ts
@@ -20,7 +20,20 @@ type ControlWithOptionalName = AbstractControl & {
 };
 
 type FormContainer = FormGroup | FormArray;
-type ErrorList = string[] & { warnings?: string[] };
+
+/**
+ * Result of {@link getAllFormErrors}. Errors and warnings are exposed as
+ * sibling records keyed by dotted field path so consumers can iterate either
+ * independently — no non-enumerable side-channels.
+ *
+ * @publicApi
+ */
+export type NgxFormErrorsByPath = {
+  /** Blocking validation errors keyed by field path. */
+  errors: Record<string, string[]>;
+  /** Non-blocking validation warnings keyed by field path. */
+  warnings: Record<string, string[]>;
+};
 
 const ERROR_MESSAGES_KEY = 'errors';
 const WARNING_MESSAGES_KEY = 'warnings';
@@ -274,10 +287,11 @@ export function setValueAtPath(
  */
 export function getAllFormErrors(
   form?: AbstractControl
-): Record<string, string[]> {
-  const errors: Record<string, ErrorList> = {};
+): NgxFormErrorsByPath {
+  const errors: Record<string, string[]> = {};
+  const warnings: Record<string, string[]> = {};
   if (!form) {
-    return errors;
+    return { errors, warnings };
   }
 
   // Collect root form errors (from ValidateRootFormDirective) before processing children
@@ -321,7 +335,6 @@ export function getAllFormErrors(
       }
     }
 
-    // Attach control errors (both errors and warnings)
     if (control.enabled) {
       const fieldErrors = getStringArrayError(
         control.errors,
@@ -330,23 +343,12 @@ export function getAllFormErrors(
       if (fieldErrors) {
         errors[pathString] = fieldErrors;
       }
-      // Optionally, add warnings if present
       const fieldWarnings = getStringArrayError(
         control.errors,
         WARNING_MESSAGES_KEY
       );
       if (fieldWarnings) {
-        // Attach warnings as a property on the error array (non-enumerable)
-        // This is still done here for field-specific warnings, but not for root warnings.
-        if (!errors[pathString]) {
-          errors[pathString] = []; // Ensure array exists if only warnings are present
-        }
-        Object.defineProperty(errors[pathString], 'warnings', {
-          value: fieldWarnings,
-          enumerable: false, // Keep it non-enumerable as per previous behavior for field warnings
-          configurable: true,
-          writable: true,
-        });
+        warnings[pathString] = fieldWarnings;
       }
     }
   }
@@ -356,5 +358,5 @@ export function getAllFormErrors(
   // Root form errors (form.errors) are no longer processed here.
   // They are handled directly in NgxFormDirective to populate formState.root.
 
-  return errors;
+  return { errors, warnings };
 }

--- a/projects/ngx-vest-forms/src/lib/utils/form-utils.ts
+++ b/projects/ngx-vest-forms/src/lib/utils/form-utils.ts
@@ -275,15 +275,20 @@ export function setValueAtPath(
 }
 
 /**
- * @internal
- * Internal utility for collecting all form errors by field path.
+ * Collects all errors and warnings reachable from `form` keyed by dotted
+ * field path.
  *
- * **Not intended for external use.** This function is used internally by the library
- * to generate the form state. Use the `formState()` signal from the `ngxVestForm` directive
- * to access form errors in your components.
+ * Root-form (`ROOT_FORM`) entries come from `form.errors.errors` and
+ * `form.errors.warnings` — the shape `ValidateRootFormDirective` writes.
+ * Field-level entries come from each descendant control's `errors.errors`
+ * and `errors.warnings`. Disabled controls are skipped.
  *
- * Traverses the form and returns the errors by path
- * @param form
+ * Inside templates and components, prefer the directive's `formState()` and
+ * `fieldWarnings()` signals — they're reactive and already memoised. Reach
+ * for this function when you need a one-shot snapshot, e.g. for logging or
+ * structured-clone-friendly serialisation.
+ *
+ * @publicApi
  */
 export function getAllFormErrors(
   form?: AbstractControl
@@ -294,11 +299,19 @@ export function getAllFormErrors(
     return { errors, warnings };
   }
 
-  // Collect root form errors (from ValidateRootFormDirective) before processing children
+  // Collect root form errors / warnings (from ValidateRootFormDirective) before
+  // processing children so they appear under the ROOT_FORM key.
   if (form.enabled) {
     const rootErrors = getStringArrayError(form.errors, ERROR_MESSAGES_KEY);
     if (rootErrors) {
       errors[ROOT_FORM] = rootErrors;
+    }
+    const rootWarnings = getStringArrayError(
+      form.errors,
+      WARNING_MESSAGES_KEY
+    );
+    if (rootWarnings) {
+      warnings[ROOT_FORM] = rootWarnings;
     }
   }
 
@@ -354,9 +367,6 @@ export function getAllFormErrors(
   }
 
   collect(form, []);
-
-  // Root form errors (form.errors) are no longer processed here.
-  // They are handled directly in NgxFormDirective to populate formState.root.
 
   return { errors, warnings };
 }

--- a/projects/ngx-vest-forms/src/public-api.ts
+++ b/projects/ngx-vest-forms/src/public-api.ts
@@ -74,13 +74,13 @@ export type { AriaAssociationMode } from './lib/utils/aria-association.utils';
   shallowEqual,
 } from './lib/utils/equality';
 /** @internal */ export { parseFieldPath } from './lib/utils/field-path.utils';
+export { getAllFormErrors } from './lib/utils/form-utils';
+export type { NgxFormErrorsByPath } from './lib/utils/form-utils';
 /** @internal */ export {
-  getAllFormErrors,
   getFormControlField,
   getFormGroupField,
   mergeValuesAndRawValues,
 } from './lib/utils/form-utils';
-export type { NgxFormErrorsByPath } from './lib/utils/form-utils';
 
 // Constants
 export { ROOT_FORM } from './lib/constants';

--- a/projects/ngx-vest-forms/src/public-api.ts
+++ b/projects/ngx-vest-forms/src/public-api.ts
@@ -80,6 +80,7 @@ export type { AriaAssociationMode } from './lib/utils/aria-association.utils';
   getFormGroupField,
   mergeValuesAndRawValues,
 } from './lib/utils/form-utils';
+export type { NgxFormErrorsByPath } from './lib/utils/form-utils';
 
 // Constants
 export { ROOT_FORM } from './lib/constants';


### PR DESCRIPTION
## Summary

Closes #115. Pre-beta.0 work per the v3 plan.

- Replace `getAllFormErrors`'s return shape (`Record<string, string[]>` with a non-enumerable `warnings` side-channel on each errors array) with a discriminated, sibling-record shape: `{ errors: Record<string, string[]>; warnings: Record<string, string[]> }`.
- Export the new type as `NgxFormErrorsByPath` from `public-api`.
- Drop the internal `ErrorList = string[] & { warnings?: string[] }` alias and the `Object.defineProperty(... 'warnings' ...)` write.
- Internal callers in `FormDirective` extract `.errors` from the new shape — `formState.errors` and the `errorsChange` output keep their externally observable shape (warnings on those signals were already invisible to JSON / spreads / structuredClone).
- v2→v3 migration guide gains a section with before/after consumer code and points template warning consumers at the existing `fieldWarnings()` signal.

## Why pre-beta.0

`#117`'s PRD bundles cleanup + Phase 1 refactors into `3.0.0-beta.0`. Shipping `getAllFormErrors`'s shape now means the first published beta is the last shape consumers will see — no breaking again in `beta.1`.

## Test plan

- [x] `npm run test:ci` — 202 lib + 21 example tests pass on the new shape
- [x] `npm run build:ci` — library and examples build clean
- [x] `form-utils.spec.ts` rewritten to assert sibling records and the absence of any non-enumerable `warnings` property on the errors arrays (regression guard)
- [x] `validate-root-form.directive.spec.ts` direct `getAllFormErrors(...)` calls updated to read `.errors[ROOT_FORM]`
- [x] `errorsChange` integration tests in `form.directive.spec.ts` and `validate-root-form.directive.spec.ts` left untouched — they consume the output, whose shape is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)