### PR TITLE
forms: extract form contract diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A lightweight, type-safe adapter between Angular template-driven forms and [Vest
 ## Why ngx-vest-forms?
 
 - Unidirectional state with Angular signals
-- Type-safe template-driven forms with runtime shape validation (dev only)
+- Type-safe template-driven forms with development-time form contract diagnostics
 - Powerful Vest.js validations (sync/async, conditional, composable)
 - Minimal boilerplate: controls and validation wiring are automatic
 
@@ -114,7 +114,7 @@ That's all you need. The directive automatically creates controls, wires validat
 ## Key Features
 
 - **Unidirectional state with signals** — Models are `NgxDeepPartial<T>` so values build up incrementally
-- **Type-safe with runtime shape validation** — Automatic control creation and validation wiring (dev mode checks)
+- **Type-safe with development-time contract diagnostics** — Automatic control creation and validation wiring (dev mode checks)
 - **Vest.js validations** — Sync/async, conditional, composable patterns with `only(field)` optimization
 - **Error display modes** — Control when errors show: `on-blur`, `on-submit`, `on-blur-or-submit` (default), `on-dirty`, or `always`
 - **Warning display modes** — Control when warnings show: `on-touch`, `on-validated-or-touch` (default), `on-dirty`, or `always`
@@ -330,7 +330,11 @@ protected handleFieldBlur(event: NgxFieldBlurEvent<FormModel>): void {
 >
   <ngx-control-wrapper>
     <label for="projectName">Project name</label>
-    <input id="projectName" name="projectName" [ngModel]="formValue().projectName" />
+    <input
+      id="projectName"
+      name="projectName"
+      [ngModel]="formValue().projectName"
+    />
   </ngx-control-wrapper>
 </form>
 ```
@@ -444,9 +448,9 @@ submitBoth() {
 
 📖 **[Complete Guide: Structure Change Detection](./docs/STRUCTURE_CHANGE_DETECTION.md)**
 
-### Shape Validation (Development Mode)
+### Form Contract Diagnostics (Development Mode)
 
-In development mode, ngx-vest-forms validates that your form's structure matches your TypeScript model, catching common mistakes early:
+In development mode, ngx-vest-forms can lint the live form value against a form contract, catching common mistakes early. New code should prefer reusing an existing Standard Schema (for example Zod or Valibot) via `provideFormContract(schema)`. Legacy `NgxDeepRequired<T>` object contracts still work as a migration-friendly fallback:
 
 ```typescript
 // Your model
@@ -455,8 +459,8 @@ type MyFormModel = NgxDeepPartial<{
   address: { street: string; city: string };
 }>;
 
-// Define shape for runtime validation
-const shape: NgxDeepRequired<MyFormModel> = {
+// Legacy fallback contract for development-time diagnostics
+const legacyContract: NgxDeepRequired<MyFormModel> = {
   email: '',
   address: { street: '', city: '' },
 };
@@ -464,17 +468,17 @@ const shape: NgxDeepRequired<MyFormModel> = {
 
 ```typescript
 @Component({
-  providers: [provideFormContract(shape)],
+  providers: [provideFormContract(legacyContract)],
   template: `
     <form ngxVestForm [suite]="suite">
-      <!-- ✅ Correct: matches shape -->
+      <!-- ✅ Correct: matches contract -->
       <input name="email" [ngModel]="formValue().email" />
       <input name="address.street" [ngModel]="formValue().address?.street" />
 
       <!-- ❌ Error in dev mode: typo detected -->
       <input name="emial" [ngModel]="formValue().email" />
 
-      <!-- ❌ Error in dev mode: path doesn't exist in shape -->
+      <!-- ❌ Error in dev mode: path doesn't exist in contract -->
       <input name="address.zipcode" [ngModel]="formValue().address?.zipcode" />
     </form>
   `,
@@ -487,11 +491,16 @@ If the contract genuinely varies per usage site, `[formContract]` still works as
 **Benefits:**
 
 - Catch typos in `name` attributes immediately during development
-- Ensure template structure matches TypeScript model
+- Reuse an existing schema instead of maintaining a separate contract object
+- Ensure template structure matches your contract or schema
 - Zero runtime cost in production (checks disabled automatically)
 - Works with nested objects and arrays
 
-**Important**: Shape validation only runs in development mode (`isDevMode()` returns `true`). Production builds have zero overhead.
+**Important**:
+
+- Contract diagnostics only run in development mode (`isDevMode()` returns `true`).
+- Unknown-key warnings depend on the strictness of the supplied Standard Schema. Legacy `NgxDeepRequired<T>` contracts keep the old extra-property typo checks.
+- The directive only consumes **synchronous** contract results for diagnostics. Async schemas are ignored by this development-only pass.
 
 📖 **[Complete Guide: Field Paths](./docs/FIELD-PATHS.md)**
 
@@ -541,7 +550,7 @@ The `[formShape]` input on `<form ngxVestForm>` is replaced by `[formContract]`,
 <!-- v2 -->
 <form ngxVestForm [suite]="suite" [formShape]="shape"></form>
 
-<!-- v3: shape still works (recommended for incremental migration) -->
+<!-- v3: legacy shape fallback still works -->
 <form ngxVestForm [suite]="suite" [formContract]="shape"></form>
 
 <!-- v3: explicit conversion to StandardSchemaV1 -->

--- a/docs/COMPLETE-EXAMPLE.md
+++ b/docs/COMPLETE-EXAMPLE.md
@@ -21,12 +21,14 @@ type UserFormModel = NgxDeepPartial<{
   email: string;
 }>;
 
-// 2. Create a shape for runtime validation (recommended)
+// 2. Define a form contract
 const userFormContract: NgxDeepRequired<UserFormModel> = {
   firstName: '',
   lastName: '',
   email: '',
 };
+
+// New code can also reuse an existing Standard Schema here.
 
 // 3. Create a Vest validation suite
 const userValidationSuite: NgxVestSuite<UserFormModel> = create(
@@ -106,7 +108,7 @@ export class UserFormComponent {
 - ✅ **Automatic form control creation** - No manual FormControl definitions
 - ✅ **Validation on blur and submit** - Default error display modes
 - ✅ **Error display** with built-in `ngx-control-wrapper`
-- ✅ **Runtime shape validation** - Catches typos in development mode
+- ✅ **Development-time contract diagnostics** - Catches path typos in development mode
 - ✅ **Unidirectional data flow** - Using `[ngModel]` (not `[(ngModel)]`)
 - ✅ **Performance optimized** — Field-level validation via `suite.only(field).run(model)` at call site
 - ✅ **Canonical suite typing** — Uses `NgxVestSuite<T>` in new code
@@ -126,9 +128,9 @@ type MyFormModel = NgxDeepPartial<{
 }>;
 ```
 
-### 2. Create a Shape for Runtime Validation
+### 2. Define a Form Contract
 
-Use `NgxDeepRequired` to create a shape that matches your model structure:
+Use `NgxDeepRequired` for a lightweight fallback contract when you do not already have a schema to reuse:
 
 ```typescript
 const myFormContract: NgxDeepRequired<MyFormModel> = {
@@ -137,7 +139,7 @@ const myFormContract: NgxDeepRequired<MyFormModel> = {
 };
 ```
 
-This enables shape validation in development mode to catch typos in `name` attributes.
+This enables development-time contract diagnostics to catch typos in `name` attributes. If you already have a Standard Schema (for example Zod), prefer reusing that instead of maintaining a separate object contract.
 
 ### 3. Suite Callbacks Take Only the Model
 

--- a/docs/TYPE-COMPATIBILITY.md
+++ b/docs/TYPE-COMPATIBILITY.md
@@ -79,7 +79,7 @@ A repo-wide find-and-replace from `NgxTypedVestSuite` to `NgxVestSuite` is safe.
 
 ## Date field compatibility
 
-When using `Date` fields in deep-partial form models, shape validation supports the common pattern where form controls start with empty strings before a date is selected:
+When using `Date` fields in deep-partial form models, legacy `NgxDeepRequired<T>` contracts support the common pattern where form controls start with empty strings before a date is selected:
 
 ```typescript
 import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
@@ -95,7 +95,7 @@ export const formContract: NgxDeepRequired<FormModel> = {
 };
 ```
 
-Compile-time typing remains strict; runtime shape validation tolerates empty-string initialization from form controls.
+Compile-time typing remains strict; development-time contract diagnostics tolerate empty-string initialization from form controls for this legacy contract style. If you already use Standard Schema, prefer modeling the date coercion directly in the schema.
 
 ## Summary
 

--- a/docs/migration/MIGRATION-v2.x-to-v3.0.0.md
+++ b/docs/migration/MIGRATION-v2.x-to-v3.0.0.md
@@ -4,19 +4,19 @@
 
 v3.0.0 deletes every `@deprecated` runtime helper, const alias, and type alias that v2.x kept around for backward compatibility. Consumers who migrated to the recommended `Ngx`-prefixed names need no changes; consumers still on the deprecated forms get a compile error pointing at the replacement.
 
-| Removed                                     | Replacement                        | Migration tip                                                            |
-| ------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------ |
-| `cloneDeep(value)`                          | `structuredClone(value)`           | Native browser/Node API; no import needed.                               |
-| `set(obj, path, value)`                     | `setValueAtPath(obj, path, value)` | Already exported from `ngx-vest-forms`; identical signature.             |
-| `vestForms` (const array)                   | `NgxVestForms`                     | `import { NgxVestForms } from 'ngx-vest-forms';` — same array, renamed.  |
-| `ROOT_FORM_CONSTANT`                        | `ROOT_FORM`                        | Single canonical export from `ngx-vest-forms`.                           |
-| `DeepPartial<T>`                            | `NgxDeepPartial<T>`                | Structurally identical; rename the import.                               |
-| `DeepRequired<T>`                           | `NgxDeepRequired<T>`               | Structurally identical; rename the import.                               |
+| Removed                                     | Replacement                        | Migration tip                                                                                                                                                         |
+| ------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cloneDeep(value)`                          | `structuredClone(value)`           | Native browser/Node API; no import needed.                                                                                                                            |
+| `set(obj, path, value)`                     | `setValueAtPath(obj, path, value)` | Already exported from `ngx-vest-forms`; identical signature.                                                                                                          |
+| `vestForms` (const array)                   | `NgxVestForms`                     | `import { NgxVestForms } from 'ngx-vest-forms';` — same array, renamed.                                                                                               |
+| `ROOT_FORM_CONSTANT`                        | `ROOT_FORM`                        | Single canonical export from `ngx-vest-forms`.                                                                                                                        |
+| `DeepPartial<T>`                            | `NgxDeepPartial<T>`                | Structurally identical; rename the import.                                                                                                                            |
+| `DeepRequired<T>`                           | `NgxDeepRequired<T>`               | Structurally identical; rename the import.                                                                                                                            |
 | `FormCompatibleDeepRequired<T>`             | _(removed)_                        | See "Replacing `NgxFormCompatibleDeepRequired`" below for a copy-paste snippet, or express Date coercion in your schema (e.g., `z.union([z.date(), z.literal('')])`). |
-| `NgxTypedVestSuite<T>`                      | `NgxVestSuite<T>`                  | Structurally identical; rename the type reference.                       |
-| `SC_ERROR_DISPLAY_MODE_DEFAULT` (re-export) | `NGX_ERROR_DISPLAY_MODE_DEFAULT`   | Was an internal re-export; if you imported it, switch to the `NGX_*` name. |
-| `[formShape]` input                         | `[formContract]`                   | See "`[formShape]` → `[formContract]`" below. Raw `NgxDeepRequired<T>` shapes are still accepted; wrap with `toFormContract(shape)` for explicit conversion. |
-| `NgxFormCompatibleDeepRequired<T>`          | _(removed)_                        | See "Replacing `NgxFormCompatibleDeepRequired`" below.                   |
+| `NgxTypedVestSuite<T>`                      | `NgxVestSuite<T>`                  | Structurally identical; rename the type reference.                                                                                                                    |
+| `SC_ERROR_DISPLAY_MODE_DEFAULT` (re-export) | `NGX_ERROR_DISPLAY_MODE_DEFAULT`   | Was an internal re-export; if you imported it, switch to the `NGX_*` name.                                                                                            |
+| `[formShape]` input                         | `[formContract]`                   | See "`[formShape]` → `[formContract]`" below. Raw `NgxDeepRequired<T>` shapes are still accepted; wrap with `toFormContract(shape)` for explicit conversion.          |
+| `NgxFormCompatibleDeepRequired<T>`          | _(removed)_                        | See "Replacing `NgxFormCompatibleDeepRequired`" below.                                                                                                                |
 
 If you only used the recommended `Ngx*` / `NGX_*` names (or the canonical `setValueAtPath` / `structuredClone`), v3 is a no-op for this category.
 
@@ -32,13 +32,19 @@ The `[formShape]` input on `<form ngxVestForm>` is removed in v3 and replaced by
 <form ngxVestForm [suite]="suite" [formContract]="myContract"></form>
 
 <!-- v3: explicit conversion to StandardSchemaV1 -->
-<form ngxVestForm [suite]="suite" [formContract]="toFormContract(myContract)"></form>
+<form
+  ngxVestForm
+  [suite]="suite"
+  [formContract]="toFormContract(myContract)"
+></form>
 
 <!-- v3: real Standard Schema (recommended for new code) -->
 <form ngxVestForm [suite]="suite" [formContract]="zodSchema"></form>
 ```
 
 `@standard-schema/spec` is now a `peerDependency` (`>=1.0.0`). Most consumers don't need to install it directly — bring it in only if you author your own `StandardSchemaV1<T>` literals. The internal `validateShape()` helper has been removed; use `toFormContract()` from `ngx-vest-forms` if you need explicit shape→schema conversion.
+
+Unknown-key warnings now depend on the strictness of the supplied Standard Schema. If you keep using a raw `NgxDeepRequired<T>` contract, the legacy extra-property typo checks still apply. The directive only consumes **synchronous** contract results for its development-only diagnostics; async schema results are ignored by that pass.
 
 ### Replacing `NgxFormCompatibleDeepRequired`
 
@@ -69,32 +75,42 @@ type _IsTuple<T extends ReadonlyArray<any>> = number extends T['length']
 export type FormCompatibleDeepRequired<T> = T extends Date
   ? Date | string
   : T extends Error
-  ? Required<T>
-  : T extends _Builtin
-  ? T
-  : T extends Map<infer K, infer V>
-  ? Map<FormCompatibleDeepRequired<K>, FormCompatibleDeepRequired<V>>
-  : T extends ReadonlyMap<infer K, infer V>
-  ? ReadonlyMap<FormCompatibleDeepRequired<K>, FormCompatibleDeepRequired<V>>
-  : T extends WeakMap<infer K, infer V>
-  ? WeakMap<FormCompatibleDeepRequired<K> & object, FormCompatibleDeepRequired<V>>
-  : T extends Set<infer U>
-  ? Set<FormCompatibleDeepRequired<U>>
-  : T extends ReadonlySet<infer U>
-  ? ReadonlySet<FormCompatibleDeepRequired<U>>
-  : T extends WeakSet<infer U>
-  ? WeakSet<FormCompatibleDeepRequired<U> & object>
-  : T extends Promise<infer U>
-  ? Promise<FormCompatibleDeepRequired<U>>
-  : T extends ReadonlyArray<infer U>
-  ? _IsNever<_IsTuple<T>> extends false
-    ? { [K in keyof T]-?: FormCompatibleDeepRequired<T[K]> }
-    : T extends Array<U>
-    ? Array<Exclude<FormCompatibleDeepRequired<U>, undefined>>
-    : ReadonlyArray<Exclude<FormCompatibleDeepRequired<U>, undefined>>
-  : T extends {}
-  ? { [K in keyof T]-?: FormCompatibleDeepRequired<T[K]> }
-  : Required<T>;
+    ? Required<T>
+    : T extends _Builtin
+      ? T
+      : T extends Map<infer K, infer V>
+        ? Map<FormCompatibleDeepRequired<K>, FormCompatibleDeepRequired<V>>
+        : T extends ReadonlyMap<infer K, infer V>
+          ? ReadonlyMap<
+              FormCompatibleDeepRequired<K>,
+              FormCompatibleDeepRequired<V>
+            >
+          : T extends WeakMap<infer K, infer V>
+            ? WeakMap<
+                FormCompatibleDeepRequired<K> & object,
+                FormCompatibleDeepRequired<V>
+              >
+            : T extends Set<infer U>
+              ? Set<FormCompatibleDeepRequired<U>>
+              : T extends ReadonlySet<infer U>
+                ? ReadonlySet<FormCompatibleDeepRequired<U>>
+                : T extends WeakSet<infer U>
+                  ? WeakSet<FormCompatibleDeepRequired<U> & object>
+                  : T extends Promise<infer U>
+                    ? Promise<FormCompatibleDeepRequired<U>>
+                    : T extends ReadonlyArray<infer U>
+                      ? _IsNever<_IsTuple<T>> extends false
+                        ? { [K in keyof T]-?: FormCompatibleDeepRequired<T[K]> }
+                        : T extends Array<U>
+                          ? Array<
+                              Exclude<FormCompatibleDeepRequired<U>, undefined>
+                            >
+                          : ReadonlyArray<
+                              Exclude<FormCompatibleDeepRequired<U>, undefined>
+                            >
+                      : T extends {}
+                        ? { [K in keyof T]-?: FormCompatibleDeepRequired<T[K]> }
+                        : Required<T>;
 ```
 
 ## What's new in v3 beyond Vest 6
@@ -123,9 +139,9 @@ import { fromEvent, lastValueFrom, takeUntil } from 'rxjs';
 
 test('userId', 'User ID is already taken', async ({ signal }) => {
   const exists = await lastValueFrom(
-    swapiService.userIdExists(model.userId!).pipe(
-      takeUntil(fromEvent(signal, 'abort'))
-    )
+    swapiService
+      .userIdExists(model.userId!)
+      .pipe(takeUntil(fromEvent(signal, 'abort')))
   );
 
   enforce(exists).isFalsy();
@@ -149,15 +165,20 @@ export const profileSuite = create((model: ProfileModel) => {
     enforce(model.userId).isNotBlank();
   });
 
-  skipWhen((res) => res.hasErrors('userId'), () => {
-    memo(() => {
-      test('userId', 'User ID is already taken', async ({ signal }) => {
-        const response = await fetch(`/api/users/${model.userId}`, { signal });
-        const { exists } = await response.json();
-        enforce(exists).isFalsy();
-      });
-    }, [model.userId]);
-  });
+  skipWhen(
+    (res) => res.hasErrors('userId'),
+    () => {
+      memo(() => {
+        test('userId', 'User ID is already taken', async ({ signal }) => {
+          const response = await fetch(`/api/users/${model.userId}`, {
+            signal,
+          });
+          const { exists } = await response.json();
+          enforce(exists).isFalsy();
+        });
+      }, [model.userId]);
+    }
+  );
 });
 ```
 

--- a/packages/ngx-vest-forms/src/lib/directives/form.directive.spec.ts
+++ b/packages/ngx-vest-forms/src/lib/directives/form.directive.spec.ts
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { isObservable, Observable } from 'rxjs';
 import { create, enforce, test as vestTest, warn } from 'vest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { StandardSchemaV1 } from '../../public-api';
 import { FormDirective, NgxFieldBlurEvent } from '../directives/form.directive';
 import { NgxVestForms } from '../exports';
 import { provideFormContract } from '../tokens/form-contract.token';
@@ -31,6 +32,44 @@ function expectElement<T extends Element>(
     throw new Error(`Expected element matching "${selector}" to be present`);
   }
   return value;
+}
+
+type TestContractIssuePathSegment = string | number | { key: string | number };
+type TestContractIssue = {
+  message: string;
+  path?: ReadonlyArray<TestContractIssuePathSegment>;
+};
+
+function createIssueContract(
+  issues: readonly TestContractIssue[] = []
+): StandardSchemaV1<Record<string, unknown>> {
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'ngx-vest-forms-tests',
+      validate(value) {
+        return issues.length > 0
+          ? { issues: [...issues] }
+          : { value: value as Record<string, unknown> };
+      },
+    },
+  };
+}
+
+function createAsyncIssueContract(
+  issues: readonly TestContractIssue[]
+): StandardSchemaV1<Record<string, unknown>> {
+  return {
+    '~standard': {
+      version: 1,
+      vendor: 'ngx-vest-forms-tests',
+      async validate(value) {
+        return issues.length > 0
+          ? { issues: [...issues] }
+          : { value: value as Record<string, unknown> };
+      },
+    },
+  };
 }
 
 @Component({
@@ -1806,20 +1845,20 @@ describe('FormDirective - first invalid helpers', () => {
   });
 });
 
-describe('FormDirective - Shape Validation', () => {
+describe('FormDirective - Form Contracts', () => {
   @Component({
-    selector: 'test-shape-validation-host',
+    selector: 'test-legacy-shape-contract-host',
     template: `<form
       ngxVestForm
-      [formContract]="formShape()"
+      [formContract]="legacyContract()"
       [formValue]="formValue()"
       #vest="ngxVestForm"
     ></form>`,
 
     imports: [NgxVestForms],
   })
-  class TestShapeValidationHost {
-    formShape = signal<{ username: string }>({ username: '' });
+  class TestLegacyShapeContractHost {
+    legacyContract = signal<{ username: string }>({ username: '' });
     formValue = signal<any>({ username: 'initial' });
     readonly vestForm =
       viewChild.required<FormDirective<Record<string, unknown>>>('vest');
@@ -1877,6 +1916,51 @@ describe('FormDirective - Shape Validation', () => {
       viewChild.required<FormDirective<Record<string, unknown>>>('vest');
   }
 
+  @Component({
+    selector: 'test-schema-issue-contract-host',
+    template: `<form
+      ngxVestForm
+      [formContract]="formContract()"
+      [formValue]="formValue()"
+      #vest="ngxVestForm"
+    ></form>`,
+    imports: [NgxVestForms],
+  })
+  class TestSchemaIssueContractHost {
+    formContract = signal<StandardSchemaV1<Record<string, unknown>>>(
+      createIssueContract()
+    );
+    formValue = signal<Record<string, unknown>>({});
+    readonly vestForm =
+      viewChild.required<FormDirective<Record<string, unknown>>>('vest');
+  }
+
+  @Component({
+    selector: 'test-partial-legacy-contract-host',
+    template: `<form
+      ngxVestForm
+      [formContract]="formContract()"
+      [formValue]="formValue()"
+      #vest="ngxVestForm"
+    ></form>`,
+    imports: [NgxVestForms],
+  })
+  class TestPartialLegacyContractHost {
+    formContract = signal({
+      user: {
+        name: '',
+        email: '',
+      },
+    });
+    formValue = signal<Record<string, unknown>>({
+      user: {
+        name: 'Ada',
+      },
+    });
+    readonly vestForm =
+      viewChild.required<FormDirective<Record<string, unknown>>>('vest');
+  }
+
   let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -1887,11 +1971,9 @@ describe('FormDirective - Shape Validation', () => {
     consoleWarnSpy.mockRestore();
   });
 
-  it('should warn in dev mode if form value shape does not match formShape', async () => {
-    // Only run this test if isDevMode is true
-    const { fixture } = await render(TestShapeValidationHost);
+  it('should warn in dev mode if a legacy shape contract does not match the form value', async () => {
+    const { fixture } = await render(TestLegacyShapeContractHost);
     const instance = fixture.componentInstance;
-    // Simulate a value change that triggers shape validation
     instance.formValue.set({ foo: 'bar' });
     fixture.detectChanges();
     expect(consoleWarnSpy).toHaveBeenCalled();
@@ -1923,7 +2005,9 @@ describe('FormDirective - Shape Validation', () => {
     await fixture.whenStable();
 
     expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("'providerOnly'"));
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("'providerOnly'")
+    );
   });
 
   it('should allow explicit [formContract]="null" to disable an injected form contract', async () => {
@@ -1943,11 +2027,122 @@ describe('FormDirective - Shape Validation', () => {
   it('should not warn in production mode', async () => {
     // This test is skipped in prod builds; in real prod, shape validation is a no-op
     // Here, we just ensure no warning if shape is correct
-    const { fixture } = await render(TestShapeValidationHost);
+    const { fixture } = await render(TestLegacyShapeContractHost);
     const instance = fixture.componentInstance;
     instance.formValue.set({ username: 'ok' });
     fixture.detectChanges();
     expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should format nested and root Standard Schema issue paths using Angular field syntax', async () => {
+    const { fixture } = await render(TestSchemaIssueContractHost);
+    const instance = fixture.componentInstance;
+    await fixture.whenStable();
+    consoleWarnSpy.mockClear();
+
+    instance.formContract.set(
+      createIssueContract([
+        {
+          message: 'Invalid user email',
+          path: ['users', { key: 0 }, 'email'],
+        },
+        {
+          message: 'Whole contract failed',
+        },
+      ])
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(2);
+    expect(consoleWarnSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('users[0].email')
+    );
+    expect(consoleWarnSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('<root>')
+    );
+  });
+
+  it('should allow partial values with a legacy shape contract', async () => {
+    await render(TestPartialLegacyContractHost);
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should rely on schema strictness for unknown-key warnings', async () => {
+    const { fixture } = await render(TestSchemaIssueContractHost);
+    const instance = fixture.componentInstance;
+    instance.formValue.set({ known: 'ok', unexpected: 'value' });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    consoleWarnSpy.mockClear();
+
+    instance.formContract.set(
+      createIssueContract([
+        {
+          message: 'Unexpected key',
+          path: ['unexpected'],
+        },
+      ])
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("'unexpected'")
+    );
+
+    consoleWarnSpy.mockClear();
+    instance.formContract.set(createIssueContract());
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should keep runtime validity independent from contract warnings', async () => {
+    const { fixture } = await render(TestSchemaIssueContractHost);
+    const instance = fixture.componentInstance;
+    await fixture.whenStable();
+    consoleWarnSpy.mockClear();
+
+    instance.formContract.set(
+      createIssueContract([
+        {
+          message: 'Unexpected key',
+          path: ['unexpected'],
+        },
+      ])
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(instance.vestForm().valid()).toBe(true);
+  });
+
+  it('should ignore async schema issues in the directive diagnostic pass', async () => {
+    const { fixture } = await render(TestSchemaIssueContractHost);
+    const instance = fixture.componentInstance;
+    await fixture.whenStable();
+    consoleWarnSpy.mockClear();
+
+    instance.formContract.set(
+      createAsyncIssueContract([
+        {
+          message: 'Async issue',
+          path: ['username'],
+        },
+      ])
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await Promise.resolve();
+
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+    expect(instance.vestForm().valid()).toBe(true);
   });
 });
 

--- a/packages/ngx-vest-forms/src/lib/directives/form.directive.ts
+++ b/packages/ngx-vest-forms/src/lib/directives/form.directive.ts
@@ -28,6 +28,7 @@ import {
   StatusChangeEvent,
   ValueChangeEvent,
 } from '@angular/forms';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import {
   catchError,
   distinctUntilChanged,
@@ -40,14 +41,13 @@ import {
   switchMap,
   take,
 } from 'rxjs';
-import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { logWarning, NGX_VEST_FORMS_ERRORS } from '../errors/error-catalog';
 import { NGX_VALIDATION_CONFIG_DEBOUNCE_TOKEN } from '../tokens/debounce.token';
 import { NGX_EQUALITY_FN } from '../tokens/equality.token';
 import {
   NGX_FORM_CONTRACT,
-  readFormContract,
   type NgxFormContractSource,
+  readFormContract,
 } from '../tokens/form-contract.token';
 import { collectTouchedPaths } from '../utils/collect-touched-paths';
 import type { NgxDeepRequired } from '../utils/deep-required';
@@ -62,13 +62,13 @@ import {
   resolveFirstInvalidFocusTarget,
   resolveFirstInvalidScrollBehavior,
 } from '../utils/first-invalid.utils';
+import { validateFormContract } from '../utils/form-contract';
 import { NgxFormState } from '../utils/form-state.utils';
 import {
   getAllFormErrors,
   mergeValuesAndRawValues,
   setValueAtPath,
 } from '../utils/form-utils';
-import { toFormContract } from '../utils/to-form-contract';
 import {
   createValidationConfigPipeline,
   type ValidationConfigPipelineOptions,
@@ -195,7 +195,9 @@ export class FormDirective<T extends Record<string, unknown>> {
   readonly #cdr = inject(ChangeDetectorRef);
   readonly #elementRef = inject<ElementRef<HTMLFormElement>>(ElementRef);
   readonly #configDebounceTime = inject(NGX_VALIDATION_CONFIG_DEBOUNCE_TOKEN);
-  readonly #injectedFormContract = inject(NGX_FORM_CONTRACT, { optional: true });
+  readonly #injectedFormContract = inject(NGX_FORM_CONTRACT, {
+    optional: true,
+  });
   /**
    * Deep-equality comparator. Defaults to `fastDeepEqual`; can be overridden
    * application-wide or per-component via {@link NGX_EQUALITY_FN}.
@@ -238,7 +240,7 @@ export class FormDirective<T extends Record<string, unknown>> {
     this.#formSnapshotTick();
     if (Object.keys(this.ngForm.form.controls).length === 0) {
       // No controls remain (e.g. dynamic group removal): expose `null` so
-      // consumers don't see ghost data from a previous form shape.
+      // consumers don't see ghost data from a previous form contract.
       return null;
     }
     return mergeValuesAndRawValues<T>(this.ngForm.form);
@@ -525,10 +527,10 @@ export class FormDirective<T extends Record<string, unknown>> {
 
     /**
      * Trigger contract validation if the form gets updated.
-     * In dev mode, runs the StandardSchema `~standard.validate(value)` for
-     * structural / typo lints. Legacy shape objects are normalized via
-     * `toFormContract`. Issues are logged via `logWarning`; form validity
-     * is unaffected.
+     * In dev mode, runs the contract through one Standard Schema-based
+     * diagnostic seam. Legacy `NgxDeepRequired<T>` contracts are normalized
+     * internally, synchronous issues are logged as warnings, and runtime
+     * form validity is unaffected.
      */
     if (isDevMode()) {
       effect(() => {
@@ -537,35 +539,7 @@ export class FormDirective<T extends Record<string, unknown>> {
         if (!v || !contract) {
           return;
         }
-        const schema =
-          typeof contract === 'object' && '~standard' in contract
-            ? (contract as StandardSchemaV1<NoInfer<T>>)
-            : toFormContract<T>(contract as NgxDeepRequired<T>);
-        const result = schema['~standard'].validate(v);
-        if (result instanceof Promise) {
-          // Async schemas: do not block; validateShape sync path covers
-          // the legacy case. Async schema authors are responsible for
-          // surfacing their own diagnostics.
-          return;
-        }
-        if ('issues' in result && result.issues) {
-          for (const issue of result.issues) {
-            const path = issue.path
-              ? issue.path
-                  .map((seg) =>
-                    typeof seg === 'object' && seg !== null && 'key' in seg
-                      ? String(seg.key)
-                      : String(seg)
-                  )
-                  .join('.')
-              : '<root>';
-            logWarning(
-              NGX_VEST_FORMS_ERRORS.SCHEMA_ISSUE,
-              path,
-              issue.message
-            );
-          }
-        }
+        validateFormContract(v, contract);
       });
     }
 

--- a/packages/ngx-vest-forms/src/lib/errors/error-catalog.ts
+++ b/packages/ngx-vest-forms/src/lib/errors/error-catalog.ts
@@ -2,7 +2,7 @@ export const NGX_VEST_FORMS_ERRORS = {
   EXTRA_PROPERTY: {
     code: 'NGX-001',
     message: (path: string) =>
-      `Shape mismatch: Property '${path}' is present in the form value but not defined in the form shape.`,
+      `Contract mismatch: Property '${path}' is present in the form value but not defined in the form contract.`,
   },
   TYPE_MISMATCH: {
     code: 'NGX-002',
@@ -17,7 +17,7 @@ export const NGX_VEST_FORMS_ERRORS = {
   SCHEMA_ISSUE: {
     code: 'NGX-004',
     message: (path: string, message: string) =>
-      `Schema issue at '${path}': ${message}`,
+      `Form contract issue at '${path}': ${message}`,
   },
 } as const;
 

--- a/packages/ngx-vest-forms/src/lib/utils/README.md
+++ b/packages/ngx-vest-forms/src/lib/utils/README.md
@@ -35,7 +35,7 @@ This directory contains all utility types and functions provided by ngx-vest-for
 - [Internal Equality Utilities](#internal-equality-utilities) ⚠️
   - [shallowEqual()](#shallowequal)
   - [fastDeepEqual()](#fastdeepequal)
-- [Internal Shape Validation](#internal-shape-validation) ⚠️ (removed in v3 — see [`toFormContract`](#toformcontract))
+- [Internal Shape Validation](#internal-shape-validation) ⚠️ (removed in v3 — legacy fallback only; see [`toFormContract`](#toformcontract))
 - [Standard Schema Adapter](#standard-schema-adapter)
   - [toFormContract()](#toformcontract)
 
@@ -94,7 +94,7 @@ type FormModel = NgxDeepPartial<{
   profile: { age: number };
 }>;
 
-// For runtime validation shapes
+// For fallback object contracts
 const formShape: NgxDeepRequired<FormModel> = {
   name: '',
   profile: {
@@ -105,7 +105,7 @@ const formShape: NgxDeepRequired<FormModel> = {
 
 **When to use:**
 
-- ✅ Creating form shapes for runtime validation
+- ✅ Defining fallback object contracts when you do not already have a schema
 - ✅ Ensuring complete data before API submission
 - ✅ Default values or initial state
 
@@ -880,7 +880,7 @@ const equal = fastDeepEqual({ a: 1, b: { c: 3 } }, { a: 1, b: { c: 3 } }); // tr
 
 ### toFormContract()
 
-Wraps a legacy `NgxDeepRequired<T>` shape into a [Standard Schema v1](https://standardschema.dev) compatible value, so it can be passed to `FormDirective`'s `[formContract]` input alongside real schemas (Zod v4, Valibot, hand-rolled, etc.).
+Wraps a legacy `NgxDeepRequired<T>` object contract into a [Standard Schema v1](https://standardschema.dev) compatible value, so it can be passed to `FormDirective`'s `[formContract]` input alongside real schemas (Zod v4, Valibot, hand-rolled, etc.).
 
 ```typescript
 import {
@@ -909,11 +909,11 @@ const formContract: StandardSchemaV1<FormModel> = toFormContract(formShape);
 
 **When to use:**
 
-- ✅ You have an existing `NgxDeepRequired<T>` shape from v2 and want explicit conversion
+- ✅ You have an existing `NgxDeepRequired<T>` contract from v2 and want explicit conversion
 - ✅ You want a single Standard Schema-typed contract through your whole codebase
 - 💡 New code should prefer authoring a real `StandardSchemaV1<T>` (Zod v4 schemas implement it natively)
 
-> **`validateShape` removed in v3.** The previous internal `validateShape()` utility is no longer exported. Shape diagnostics in dev mode now run through the unified Standard Schema validation path.
+> **`validateShape` removed in v3.** The previous internal `validateShape()` utility is no longer exported. Contract diagnostics in dev mode now run through the unified Standard Schema validation path. Unknown-key behavior depends on the supplied schema's strictness, and the directive only consumes synchronous contract results.
 
 ---
 

--- a/packages/ngx-vest-forms/src/lib/utils/form-contract.ts
+++ b/packages/ngx-vest-forms/src/lib/utils/form-contract.ts
@@ -1,0 +1,93 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { logWarning, NGX_VEST_FORMS_ERRORS } from '../errors/error-catalog';
+import type { NgxFormContract } from '../tokens/form-contract.token';
+import type { NgxDeepRequired } from './deep-required';
+import { stringifyFieldPath } from './field-path.utils';
+import { toFormContract } from './to-form-contract';
+
+type StandardSchemaIssuePathSegment =
+  | string
+  | number
+  | { key: string | number };
+type StandardSchemaIssue = {
+  message: string;
+  path?: readonly StandardSchemaIssuePathSegment[];
+};
+
+/**
+ * Normalizes legacy `NgxDeepRequired<T>` contracts and real Standard Schema
+ * values behind one Standard Schema seam.
+ */
+export function normalizeFormContract<T>(
+  contract: NgxFormContract<T>
+): StandardSchemaV1<T> {
+  return typeof contract === 'object' &&
+    contract !== null &&
+    '~standard' in contract
+    ? (contract as StandardSchemaV1<T>)
+    : (toFormContract<T>(
+        contract as NgxDeepRequired<T>
+      ) as StandardSchemaV1<T>);
+}
+
+/**
+ * Converts a Standard Schema issue path into the field-path format used by
+ * Angular template-driven forms and Vest.
+ */
+export function stringifyFormContractIssuePath(
+  path?: readonly StandardSchemaIssuePathSegment[]
+): string {
+  if (!path || path.length === 0) {
+    return '<root>';
+  }
+
+  const normalizedPath = path.map((segment) =>
+    typeof segment === 'object' && segment !== null && 'key' in segment
+      ? segment.key
+      : segment
+  );
+
+  return stringifyFieldPath(normalizedPath) || '<root>';
+}
+
+/**
+ * Emits development warnings for contract issues without affecting runtime
+ * validity. This stays intentionally separate from user-facing Vest errors.
+ */
+export function logFormContractIssues(
+  issues?: readonly StandardSchemaIssue[]
+): void {
+  if (!issues || issues.length === 0) {
+    return;
+  }
+
+  for (const issue of issues) {
+    logWarning(
+      NGX_VEST_FORMS_ERRORS.SCHEMA_ISSUE,
+      stringifyFormContractIssuePath(issue.path),
+      issue.message
+    );
+  }
+}
+
+/**
+ * Validates a value against the supplied form contract and logs any synchronous
+ * Standard Schema issues. Async contract validators are ignored by the
+ * directive's development-only diagnostic pass.
+ */
+export function validateFormContract<T>(
+  value: T,
+  contract: NgxFormContract<T>
+): 'sync' | 'async' {
+  const result = normalizeFormContract(contract)['~standard'].validate(value);
+
+  if (result instanceof Promise) {
+    return 'async';
+  }
+
+  if ('issues' in result) {
+    logFormContractIssues(result.issues as readonly StandardSchemaIssue[]);
+  }
+
+  return 'sync';
+}

--- a/packages/ngx-vest-forms/src/lib/utils/form-contract.ts
+++ b/packages/ngx-vest-forms/src/lib/utils/form-contract.ts
@@ -78,16 +78,14 @@ export function logFormContractIssues(
 export function validateFormContract<T>(
   value: T,
   contract: NgxFormContract<T>
-): 'sync' | 'async' {
+): void {
   const result = normalizeFormContract(contract)['~standard'].validate(value);
 
   if (result instanceof Promise) {
-    return 'async';
+    return;
   }
 
   if ('issues' in result) {
     logFormContractIssues(result.issues as readonly StandardSchemaIssue[]);
   }
-
-  return 'sync';
 }


### PR DESCRIPTION
## Summary
- extract Standard Schema contract normalization and issue formatting into a dedicated internal utility
- keep `FormDirective` focused on orchestration while preserving the current development-only warning behavior
- expand directive coverage for nested paths, root issues, partial legacy contracts, schema strictness, and sync-only diagnostics
- update the docs to position schema-backed contracts ahead of legacy `NgxDeepRequired<T>` fallbacks

## Why
Issue #176 already landed the `formShape` -> `formContract` migration on `release/v3`, but the contract seam still needed follow-up cleanup. This PR finishes that pass by tightening the internal structure, documenting the intended contract-first path, and locking the current Standard Schema behavior down with tests.

## Testing
- `pnpm nx run ngx-vest-forms:lint`
- `CI=1 pnpm nx run ngx-vest-forms:test`

Refs #176