### PR TITLE
feat(examples): elevate Examples App shell with categorized nav + first-wave demos

### DIFF
--- a/apps/examples-e2e/app/app.page.spec.ts
+++ b/apps/examples-e2e/app/app.page.spec.ts
@@ -14,6 +14,9 @@ test.describe('App Page', () => {
     await page.goto('/');
 
     await expect(
+      page.getByRole('link', { name: /starter contact form/i })
+    ).toBeVisible();
+    await expect(
       page.getByRole('link', { name: /purchase form/i })
     ).toBeVisible();
     await expect(
@@ -35,10 +38,16 @@ test.describe('App Page', () => {
       page.getByRole('link', { name: /business policy/i })
     ).toBeVisible();
     await expect(
+      page.getByRole('link', { name: /conditional structure/i })
+    ).toBeVisible();
+    await expect(
       page.getByRole('link', { name: /complex nested/i })
     ).toBeVisible();
     await expect(
       page.getByRole('link', { name: /custom controls/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /accessible wrapper/i })
     ).toBeVisible();
     await expect(
       page.getByRole('link', { name: /submission patterns/i })

--- a/apps/examples-e2e/app/app.page.spec.ts
+++ b/apps/examples-e2e/app/app.page.spec.ts
@@ -28,5 +28,20 @@ test.describe('App Page', () => {
     await expect(
       page.getByRole('link', { name: /display modes demo/i })
     ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /async username/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /business policy/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /complex nested/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /custom controls/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /submission patterns/i })
+    ).toBeVisible();
   });
 });

--- a/apps/examples-e2e/helpers/form-helpers.ts
+++ b/apps/examples-e2e/helpers/form-helpers.ts
@@ -57,6 +57,10 @@ export async function navigateToDateRangeAdapter(
   ).toBeVisible();
 }
 
+export function getMainContentSidebar(page: Page): Locator {
+  return page.getByRole('main').getByRole('complementary').first();
+}
+
 /**
  * Wait for async validation to complete by monitoring aria-busy attribute
  */

--- a/apps/examples-e2e/pages/accessible-wrapper-demo/accessible-wrapper.form.spec.ts
+++ b/apps/examples-e2e/pages/accessible-wrapper-demo/accessible-wrapper.form.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+import { fillAndBlur } from '../../helpers/form-helpers';
+
+test.describe('Accessible Wrapper Demo Form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/accessible-wrapper');
+  });
+
+  test('should wire ARIA correctly for single-control and manual modes', async ({
+    page,
+  }) => {
+    const preferredName = page.getByRole('textbox', { name: /preferred name/i });
+    const searchQuery = page.getByRole('searchbox', { name: /search query/i });
+    const clearSearch = page.getByRole('button', {
+      name: /clear search query/i,
+    });
+
+    await page.getByRole('button', { name: /save preferences/i }).click();
+
+    const errorSummary = page.getByRole('alert').filter({
+      hasText: /preferred name is required/i,
+    });
+
+    await expect(errorSummary).toContainText(/preferred name is required/i);
+    await expect(errorSummary).toContainText(/search query is required/i);
+    await expect(searchQuery).toHaveAttribute('aria-invalid', 'true');
+
+    const preferredDescribedBy = await preferredName.getAttribute(
+      'aria-describedby'
+    );
+    expect(preferredDescribedBy).toMatch(/preferred-name-hint/);
+    expect(preferredDescribedBy).toMatch(/ngx-error-control-\d+-error/);
+
+    const searchDescribedBy = await searchQuery.getAttribute('aria-describedby');
+    expect(searchDescribedBy).toMatch(/search-query-hint/);
+    expect(searchDescribedBy).toMatch(/ngx-error-control-\d+-error/);
+    expect(await clearSearch.getAttribute('aria-describedby')).toBeNull();
+    expect(await clearSearch.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  test('should keep validation on the input while the helper button stays neutral', async ({
+    page,
+  }) => {
+    const preferredName = page.getByRole('textbox', { name: /preferred name/i });
+    const searchQuery = page.getByRole('searchbox', { name: /search query/i });
+
+    await fillAndBlur(preferredName, 'Ada');
+    await fillAndBlur(searchQuery, 'ngx-vest-forms');
+    await page.getByRole('button', { name: /clear search query/i }).click();
+
+    await expect(searchQuery).toHaveValue('');
+
+    await fillAndBlur(searchQuery, 'ngx-vest-forms');
+    await page.getByRole('button', { name: /save preferences/i }).click();
+
+    await expect(
+      page.getByRole('status').filter({ hasText: /preferences saved/i })
+    ).toBeVisible();
+  });
+});

--- a/apps/examples-e2e/pages/accessible-wrapper-demo/accessible-wrapper.page.spec.ts
+++ b/apps/examples-e2e/pages/accessible-wrapper-demo/accessible-wrapper.page.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Accessible Wrapper Demo Page', () => {
+  test('should render the accessible-wrapper demo shell', async ({ page }) => {
+    await page.goto('/accessible-wrapper');
+
+    await expect(
+      page.getByRole('heading', {
+        name: /accessible custom wrapper/i,
+        level: 1,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('textbox', { name: /preferred name/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('searchbox', { name: /search query/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /clear search query/i })
+    ).toBeVisible();
+  });
+});

--- a/apps/examples-e2e/pages/async-username-form/async-username.form.spec.ts
+++ b/apps/examples-e2e/pages/async-username-form/async-username.form.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+import {
+  fillAndBlur,
+  typeAndBlur,
+  waitForValidationToSettle,
+} from '../../helpers/form-helpers';
+
+test.describe('Async Username Form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/async-username', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('should surface async validation and reserve an available username', async ({
+    page,
+  }) => {
+    const username = page.getByLabel('Username', { exact: true });
+    const displayName = page.getByLabel('Display name', { exact: true });
+    const reserveButton = page.getByRole('button', {
+      name: /reserve username/i,
+    });
+    const resetButton = page.getByRole('button', { name: /reset/i });
+
+    await fillAndBlur(displayName, 'Ada Lovelace');
+
+    await typeAndBlur(username, 'taken', 0);
+    await expect(page.getByText(/checking availability/i)).toBeVisible();
+    await waitForValidationToSettle(page);
+    await expect(
+      page.getByRole('alert').getByText(/username is already taken/i)
+    ).toBeVisible();
+
+    await typeAndBlur(username, 'ada_lovelace', 0);
+    await waitForValidationToSettle(page);
+    await expect(page.getByText(/that username is available\./i)).toBeVisible();
+
+    await reserveButton.click();
+
+    const successAlert = page
+      .getByRole('status')
+      .filter({ hasText: /username reserved/i });
+    await expect(successAlert).toBeVisible();
+    await expect(successAlert).toContainText(/ada_lovelace/i);
+    await expect(successAlert).toContainText(/ada lovelace/i);
+
+    await resetButton.click();
+    await expect(username).toHaveValue('');
+    await expect(displayName).toHaveValue('');
+    await expect(successAlert).toHaveCount(0);
+  });
+});

--- a/apps/examples-e2e/pages/async-username-form/async-username.page.spec.ts
+++ b/apps/examples-e2e/pages/async-username-form/async-username.page.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Async Username Page', () => {
+  test('should render the async validation example layout', async ({ page }) => {
+    await page.goto('/async-username', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', {
+        name: /async username availability/i,
+        level: 1,
+      })
+    ).toBeVisible();
+
+    const contentAside = page
+      .getByRole('complementary')
+      .filter({ hasText: /how async validation behaves/i });
+    await expect(contentAside).toBeVisible();
+    await expect(contentAside).toContainText(/form state/i);
+    await expect(contentAside).toContainText(/form value/i);
+
+    await expect(
+      page.getByRole('textbox', { name: /username/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('textbox', { name: /display name/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /reserve username/i })
+    ).toBeVisible();
+  });
+});

--- a/apps/examples-e2e/pages/auto-save-demo/auto-save-demo.form.tests.ts
+++ b/apps/examples-e2e/pages/auto-save-demo/auto-save-demo.form.tests.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import {
   expectFieldHasError,
+  getMainContentSidebar,
   navigateToAutoSaveDemo,
   typeAndBlur,
   waitForValidationToSettle,
@@ -19,6 +20,8 @@ test.describe('Auto-Save Draft Demo', () => {
   test('should save a draft on blur and keep the saved value in sessionStorage', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await test.step('Blur a changed field to trigger draft save', async () => {
       const projectName = page.getByLabel('Project name', { exact: true });
 
@@ -30,7 +33,7 @@ test.describe('Auto-Save Draft Demo', () => {
       await expect(
         page.getByRole('heading', { name: /draft saved/i })
       ).toBeVisible();
-      await expect(page.locator('aside')).toContainText(/website refresh/i);
+      await expect(sidebar).toContainText(/website refresh/i);
     });
 
     await test.step('Verify temporary storage contains the saved draft', async () => {
@@ -76,16 +79,18 @@ test.describe('Auto-Save Draft Demo', () => {
       await page.reload();
       await navigateToAutoSaveDemo(page);
 
+      const sidebar = getMainContentSidebar(page);
+
       await expect(page.getByLabel('Project name', { exact: true })).toHaveValue(
         'Release checklist'
       );
       await expect(page.getByLabel('Draft notes', { exact: true })).toHaveValue(
         'Add deployment notes for the production team.'
       );
-      await expect(page.locator('aside')).toContainText(
+      await expect(sidebar).toContainText(
         /restored from sessionstorage for this browser tab/i
       );
-      await expect(page.locator('aside')).toContainText(/sessionstorage/i);
+      await expect(sidebar).toContainText(/sessionstorage/i);
     });
   });
 
@@ -160,6 +165,8 @@ test.describe('Auto-Save Draft Demo', () => {
   test('should show save failure and retry successfully on the next blur', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await test.step('Trigger a simulated save failure', async () => {
       const projectName = page.getByLabel('Project name', { exact: true });
 
@@ -168,9 +175,7 @@ test.describe('Auto-Save Draft Demo', () => {
       await expect(
         page.getByRole('heading', { name: /draft save failed/i })
       ).toBeVisible();
-      await expect(page.locator('aside')).toContainText(
-        /simulated save failure/i
-      );
+      await expect(sidebar).toContainText(/simulated save failure/i);
     });
 
     await test.step('Fix the draft and retry via blur', async () => {
@@ -207,6 +212,8 @@ test.describe('Auto-Save Draft Demo', () => {
   test('should discard an in-flight blur save when the form is reset', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await test.step('Start a blur save and reset before it completes', async () => {
       const projectName = page.getByLabel('Project name', { exact: true });
       const resetButton = page.getByRole('button', { name: /reset form/i });
@@ -230,7 +237,7 @@ test.describe('Auto-Save Draft Demo', () => {
         })
         .toBeNull();
 
-      await expect(page.locator('aside')).not.toContainText(/transient draft/i);
+      await expect(sidebar).not.toContainText(/transient draft/i);
     });
   });
 });

--- a/apps/examples-e2e/pages/auto-save-demo/auto-save-demo.page.spec.ts
+++ b/apps/examples-e2e/pages/auto-save-demo/auto-save-demo.page.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { navigateToAutoSaveDemo } from '../../helpers/form-helpers';
+import {
+  getMainContentSidebar,
+  navigateToAutoSaveDemo,
+} from '../../helpers/form-helpers';
 
 test.describe('Auto-Save Demo Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -9,13 +12,15 @@ test.describe('Auto-Save Demo Page', () => {
   test('should render page layout and autosave sidebar details', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await expect(
       page.getByRole('heading', { name: /auto-save draft demo/i, level: 1 })
     ).toBeVisible();
-    await expect(page.locator('aside')).toContainText(/key features/i);
-    await expect(page.locator('aside')).toContainText(/draft status/i);
-    await expect(page.locator('aside')).toContainText(/sessionstorage/i);
-    await expect(page.locator('aside')).toContainText(
+    await expect(sidebar).toContainText(/key features/i);
+    await expect(sidebar).toContainText(/draft status/i);
+    await expect(sidebar).toContainText(/sessionstorage/i);
+    await expect(sidebar).toContainText(
       /ngx-vest-forms:auto-save-demo:draft/i
     );
   });

--- a/apps/examples-e2e/pages/business-hours-form/business-hours.page.spec.ts
+++ b/apps/examples-e2e/pages/business-hours-form/business-hours.page.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { navigateToBusinessHoursForm } from '../../helpers/form-helpers';
+import {
+  getMainContentSidebar,
+  navigateToBusinessHoursForm,
+} from '../../helpers/form-helpers';
 
 test.describe('Business Hours Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,7 +14,7 @@ test.describe('Business Hours Page', () => {
       page.getByRole('heading', { name: /business hours form/i, level: 1 })
     ).toBeVisible();
 
-    const sidebar = page.getByRole('complementary').first();
+    const sidebar = getMainContentSidebar(page);
     await expect(sidebar).toBeVisible();
     await expect(sidebar).toContainText(/form value/i);
     await expect(sidebar).toContainText(/form state/i);

--- a/apps/examples-e2e/pages/business-policy-form/business-policy.form.spec.ts
+++ b/apps/examples-e2e/pages/business-policy-form/business-policy.form.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test } from '@playwright/test';
+import { fillAndBlur, waitForValidationToSettle } from '../../helpers/form-helpers';
+
+test.describe('Business Policy Form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/business-policy', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('should enforce the conditional VAT rule and allow advisory warnings', async ({
+    page,
+  }) => {
+    const accountType = page.getByRole('combobox', { name: /account type/i });
+    const legalName = page.getByLabel('Legal name', { exact: true });
+    const country = page.getByRole('combobox', { name: /country/i });
+    const vatId = page.getByLabel('VAT ID', { exact: true });
+    const annualRevenue = page.getByLabel('Annual revenue', { exact: true });
+    const requestedCreditLimit = page.getByLabel('Requested credit limit', {
+      exact: true,
+    });
+    const paymentTerms = page.getByRole('combobox', {
+      name: /payment terms \(days\)/i,
+    });
+    const submitButton = page.getByRole('button', {
+      name: /submit application/i,
+    });
+
+    await submitButton.click();
+    await expect(
+      page.getByRole('alert').filter({ hasText: /errors/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('alert').getByText(/account type is required/i)
+    ).toBeVisible();
+
+    await accountType.selectOption('business');
+    await country.selectOption('DE');
+    await expect(vatId).toBeVisible();
+
+    await fillAndBlur(legalName, 'Acme International B.V.');
+    await fillAndBlur(vatId, 'NL123456789B01');
+    await fillAndBlur(annualRevenue, '50000');
+    await fillAndBlur(requestedCreditLimit, '30000');
+    await paymentTerms.selectOption('30');
+
+    await waitForValidationToSettle(page);
+    await expect(
+      page.locator('ngx-form-state-card').getByText(/expect manual review/i)
+    ).toBeVisible();
+
+    await submitButton.click();
+
+    const successAlert = page
+      .getByRole('status')
+      .filter({ hasText: /application submitted/i });
+    await expect(successAlert).toBeVisible();
+    await expect(successAlert).toContainText(/acme international b\.v\./i);
+  });
+});

--- a/apps/examples-e2e/pages/business-policy-form/business-policy.page.spec.ts
+++ b/apps/examples-e2e/pages/business-policy-form/business-policy.page.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Business Policy Page', () => {
+  test('should render the policy demo layout', async ({ page }) => {
+    await page.goto('/business-policy', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', {
+        name: /vest-first business policy/i,
+        level: 1,
+      })
+    ).toBeVisible();
+
+    const contentAside = page
+      .getByRole('complementary')
+      .filter({ hasText: /policy at a glance/i });
+    await expect(contentAside).toBeVisible();
+    await expect(contentAside).toContainText(/form state/i);
+    await expect(contentAside).toContainText(/form value/i);
+
+    await expect(
+      page.getByRole('combobox', { name: /account type/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('combobox', { name: /country/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /submit application/i })
+    ).toBeVisible();
+  });
+});

--- a/apps/examples-e2e/pages/complex-nested-form/complex-nested.form.spec.ts
+++ b/apps/examples-e2e/pages/complex-nested-form/complex-nested.form.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+import {
+  fillAndBlur,
+  waitForValidationToSettle,
+} from '../../helpers/form-helpers';
+
+test.describe('Complex Nested Form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/complex-nested', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('should handle add/remove member flows and submit a valid team', async ({
+    page,
+  }) => {
+    const addMemberButton = page.getByRole('button', { name: /add member/i });
+    const registerButton = page.getByRole('button', { name: /register team/i });
+    const removeMember1Button = page.getByRole('button', {
+      name: /remove member 1/i,
+    });
+
+    await removeMember1Button.click();
+    await expect(page.getByText(/no team members yet/i)).toBeVisible();
+
+    await registerButton.click();
+
+    await addMemberButton.click();
+    await expect(page.getByRole('heading', { name: /member 1/i })).toBeVisible();
+
+    await fillAndBlur(
+      page.getByLabel('Company name', { exact: true }),
+      'Acme Corp'
+    );
+    await fillAndBlur(page.getByLabel('Street', { exact: true }), 'Main Street');
+    await fillAndBlur(page.getByLabel('Number', { exact: true }), '42');
+    await fillAndBlur(page.getByLabel('City', { exact: true }), 'Amsterdam');
+    await fillAndBlur(page.getByLabel('Zipcode', { exact: true }), '1011AB');
+    await fillAndBlur(page.getByLabel('Country', { exact: true }), 'NL');
+
+    const firstMemberFullName = page.getByLabel('Full name', { exact: true }).first();
+    const firstMemberEmail = page.getByLabel('Email', { exact: true }).first();
+    const firstMemberRole = page.getByLabel('Role', { exact: true }).first();
+
+    await fillAndBlur(firstMemberFullName, 'Ada Lovelace');
+    await fillAndBlur(firstMemberEmail, 'ada@example.com');
+    await fillAndBlur(firstMemberRole, 'Engineer');
+
+    await waitForValidationToSettle(page);
+    await registerButton.click();
+
+    const successAlert = page
+      .getByRole('status')
+      .filter({ hasText: /team registered/i });
+    await expect(successAlert).toBeVisible();
+    await expect(successAlert).toContainText(/acme corp/i);
+    await expect(successAlert).toContainText(/1 team member/i);
+  });
+});

--- a/apps/examples-e2e/pages/complex-nested-form/complex-nested.page.spec.ts
+++ b/apps/examples-e2e/pages/complex-nested-form/complex-nested.page.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Complex Nested Page', () => {
+  test('should render the nested repeatable demo layout', async ({ page }) => {
+    await page.goto('/complex-nested', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', {
+        name: /complex nested & repeatable form/i,
+        level: 1,
+      })
+    ).toBeVisible();
+
+    const contentAside = page
+      .getByRole('complementary')
+      .filter({ hasText: /key features/i });
+    await expect(contentAside).toBeVisible();
+    await expect(contentAside).toContainText(/form state/i);
+    await expect(contentAside).toContainText(/form value/i);
+
+    await expect(page.getByRole('button', { name: /add member/i })).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /register team/i })
+    ).toBeVisible();
+  });
+});

--- a/apps/examples-e2e/pages/conditional-structure-demo/conditional-structure.form.spec.ts
+++ b/apps/examples-e2e/pages/conditional-structure-demo/conditional-structure.form.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test';
+import { fillAndBlur, waitForValidationToSettle } from '../../helpers/form-helpers';
+
+test.describe('Conditional Structure Demo Form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/conditional-structure');
+  });
+
+  test('should clear stale values when an input branch becomes static content', async ({
+    page,
+  }) => {
+    const contactName = page.getByLabel(/contact name/i);
+    const deliveryMethod = page.getByRole('combobox', {
+      name: /delivery method/i,
+    });
+
+    await fillAndBlur(contactName, 'Ada Lovelace');
+    await deliveryMethod.selectOption('shipment');
+
+    const shippingAddress = page.getByLabel(/shipping address/i);
+    await fillAndBlur(shippingAddress, '123 Analytical Engine Way');
+    await expect(shippingAddress).toHaveValue('123 Analytical Engine Way');
+
+    await deliveryMethod.selectOption('pickup');
+
+    await expect(shippingAddress).toHaveCount(0);
+    await expect(
+      page.getByText(/no extra delivery field is required for pickup orders/i)
+    ).toBeVisible();
+    await expect(
+      page.getByText(/123 Analytical Engine Way/i)
+    ).toHaveCount(0);
+
+    await page.getByRole('button', { name: /save delivery plan/i }).click();
+
+    const submittedPayloadCard = page.locator('ngx-card').filter({
+      hasText: /submitted payload/i,
+    });
+
+    await expect(
+      page.getByRole('status').filter({ hasText: /delivery plan submitted/i })
+    ).toBeVisible();
+    await expect(submittedPayloadCard).toContainText('"deliveryMode": "pickup"');
+    await expect(submittedPayloadCard).not.toContainText('shippingAddress');
+  });
+
+  test('should switch validation to the active branch after a structure change', async ({
+    page,
+  }) => {
+    const contactName = page.getByLabel(/contact name/i);
+    const deliveryMethod = page.getByRole('combobox', {
+      name: /delivery method/i,
+    });
+
+    await fillAndBlur(contactName, 'Ada Lovelace');
+    await deliveryMethod.selectOption('digital');
+    await page.getByRole('button', { name: /save delivery plan/i }).click();
+    await waitForValidationToSettle(page);
+
+    const errorSummary = page.getByRole('alert').filter({
+      hasText: /delivery email is required/i,
+    });
+
+    const deliveryEmail = page.getByLabel(/delivery email/i);
+    await expect(deliveryEmail).toBeFocused();
+    await expect(errorSummary).toContainText(/delivery email is required/i);
+
+    await fillAndBlur(deliveryEmail, 'ada@example.com');
+    await page.getByRole('button', { name: /save delivery plan/i }).click();
+
+    const submittedPayloadCard = page.locator('ngx-card').filter({
+      hasText: /submitted payload/i,
+    });
+
+    await expect(
+      page.getByRole('status').filter({ hasText: /delivery plan submitted/i })
+    ).toBeVisible();
+    await expect(submittedPayloadCard).toContainText('ada@example.com');
+  });
+});

--- a/apps/examples-e2e/pages/conditional-structure-demo/conditional-structure.page.spec.ts
+++ b/apps/examples-e2e/pages/conditional-structure-demo/conditional-structure.page.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Conditional Structure Demo Page', () => {
+  test('should render the conditional-structure demo shell', async ({ page }) => {
+    await page.goto('/conditional-structure');
+
+    await expect(
+      page.getByRole('heading', {
+        name: /conditional structure & field clearing/i,
+        level: 1,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('textbox', { name: /contact name/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('combobox', { name: /delivery method/i })
+    ).toBeVisible();
+    await expect(page.getByText(/relevant payload/i)).toBeVisible();
+  });
+});

--- a/apps/examples-e2e/pages/custom-controls-form/custom-controls.form.spec.ts
+++ b/apps/examples-e2e/pages/custom-controls-form/custom-controls.form.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Custom Controls Form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/custom-controls', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('should validate empty controls and submit a completed custom-control form', async ({
+    page,
+  }) => {
+    const submitButton = page.getByRole('button', { name: /submit/i });
+
+    await submitButton.click();
+    await expect(
+      page.getByRole('alert').getByText(/pick a rating/i)
+    ).toBeVisible();
+    await expect(
+      page.getByRole('alert').getByText(/select your experience level/i)
+    ).toBeVisible();
+    await expect(
+      page.getByRole('alert').getByText(/add at least one tag/i)
+    ).toBeVisible();
+
+    await page.getByRole('radio', { name: /5 stars/i }).click();
+    await page.getByRole('radio', { name: /senior/i }).click();
+
+    const tagInput = page.getByLabel(/add a tag/i);
+    await tagInput.fill('angular');
+    await tagInput.press('Enter');
+
+    await expect(
+      page.getByRole('button', { name: /remove tag angular/i })
+    ).toBeVisible();
+
+    await submitButton.click();
+
+    const successAlert = page
+      .getByRole('status')
+      .filter({ hasText: /submitted/i });
+    await expect(successAlert).toBeVisible();
+    await expect(successAlert).toContainText(/rated 5\/5/i);
+    await expect(successAlert).toContainText(/senior/i);
+    await expect(successAlert).toContainText(/1 tag/i);
+  });
+});

--- a/apps/examples-e2e/pages/custom-controls-form/custom-controls.page.spec.ts
+++ b/apps/examples-e2e/pages/custom-controls-form/custom-controls.page.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Custom Controls Page', () => {
+  test('should render the custom controls layout', async ({ page }) => {
+    await page.goto('/custom-controls', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', {
+        name: /custom controls \(controlvalueaccessor\)/i,
+        level: 1,
+      })
+    ).toBeVisible();
+
+    const contentAside = page
+      .getByRole('complementary')
+      .filter({ hasText: /why this works/i });
+    await expect(contentAside).toBeVisible();
+    await expect(contentAside).toContainText(/form state/i);
+    await expect(contentAside).toContainText(/form value/i);
+
+    await expect(
+      page.getByRole('radiogroup', { name: /rating/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('radiogroup', { name: /experience level/i })
+    ).toBeVisible();
+    await expect(page.getByLabel(/add a tag/i)).toBeVisible();
+  });
+});

--- a/apps/examples-e2e/pages/date-range-adapter/composite-adapter.form.tests.ts
+++ b/apps/examples-e2e/pages/date-range-adapter/composite-adapter.form.tests.ts
@@ -1,5 +1,6 @@
 import { expect, Locator, Page, test } from '@playwright/test';
 import {
+  getMainContentSidebar,
   navigateToDateRangeAdapter,
   waitForValidationToSettle,
 } from '../../helpers/form-helpers';
@@ -81,21 +82,23 @@ test.describe('Composite Adapter - Form Behavior', () => {
   test('should update form model when departure date is entered', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
     const departure = page.getByLabel(/departure date/i);
     await setAdapterDate(departure, '2026-07-01');
     await waitForValidationToSettle(page);
 
-    await expect(page.locator('aside')).toContainText('2026-07-01');
+    await expect(sidebar).toContainText('2026-07-01');
   });
 
   test('should update form model when return date is entered', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
     const returnDate = page.getByLabel(/return date/i);
     await setAdapterDate(returnDate, '2026-07-15');
     await waitForValidationToSettle(page);
 
-    await expect(page.locator('aside')).toContainText('2026-07-15');
+    await expect(sidebar).toContainText('2026-07-15');
   });
 
   test('should show required errors on submit with empty fields', async ({

--- a/apps/examples-e2e/pages/date-range-adapter/date-range-adapter.page.spec.ts
+++ b/apps/examples-e2e/pages/date-range-adapter/date-range-adapter.page.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { navigateToDateRangeAdapter } from '../../helpers/form-helpers';
+import {
+  getMainContentSidebar,
+  navigateToDateRangeAdapter,
+} from '../../helpers/form-helpers';
 
 test.describe('Composite Adapter Recipe Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -7,15 +10,17 @@ test.describe('Composite Adapter Recipe Page', () => {
   });
 
   test('should render page layout and key sections', async ({ page }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await expect(
       page.getByRole('heading', {
         name: /composite adapter recipe/i,
         level: 1,
       })
     ).toBeVisible();
-    await expect(page.locator('aside')).toBeVisible();
-    await expect(page.locator('aside')).toContainText(/form state/i);
-    await expect(page.locator('aside')).toContainText(/how it works/i);
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar).toContainText(/form state/i);
+    await expect(sidebar).toContainText(/how it works/i);
   });
 
   test('should render approach toggle with two options', async ({ page }) => {
@@ -88,17 +93,15 @@ test.describe('Composite Adapter Recipe Page', () => {
   test('should update How It Works sidebar on approach switch', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
+
     // Default: split wrappers
-    await expect(page.locator('aside')).toContainText(/no hidden proxies/i);
-    await expect(page.locator('aside')).toContainText(
-      /no manual error aggregation/i
-    );
+    await expect(sidebar).toContainText(/no hidden proxies/i);
+    await expect(sidebar).toContainText(/no manual error aggregation/i);
 
     // Switch to composite adapter
     await page.getByRole('radio', { name: /composite adapter/i }).check();
-    await expect(page.locator('aside')).toContainText(
-      /hidden proxy fields/i
-    );
+    await expect(sidebar).toContainText(/hidden proxy fields/i);
   });
 
   test('should render date range fields in both approaches', async ({

--- a/apps/examples-e2e/pages/date-range-adapter/split-wrappers.form.tests.ts
+++ b/apps/examples-e2e/pages/date-range-adapter/split-wrappers.form.tests.ts
@@ -3,6 +3,7 @@ import {
   expectFieldHasError,
   expectFieldValid,
   fillNativeDateInputAndBlur,
+  getMainContentSidebar,
   getWarningElementFor,
   navigateToDateRangeAdapter,
   waitForValidationToSettle,
@@ -38,21 +39,23 @@ test.describe('Split Wrappers - Form Behavior', () => {
   test('should update form model when departure date is entered', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
     const departure = page.getByLabel(/departure date/i);
     await fillNativeDateInputAndBlur(departure, '2026-07-01');
     await waitForValidationToSettle(page);
 
-    await expect(page.locator('aside')).toContainText('2026-07-01');
+    await expect(sidebar).toContainText('2026-07-01');
   });
 
   test('should update form model when return date is entered', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
     const returnDate = page.getByLabel(/return date/i);
     await fillNativeDateInputAndBlur(returnDate, '2026-07-15');
     await waitForValidationToSettle(page);
 
-    await expect(page.locator('aside')).toContainText('2026-07-15');
+    await expect(sidebar).toContainText('2026-07-15');
   });
 
   test('should show required error on departure field after submit', async ({

--- a/apps/examples-e2e/pages/display-modes-demo/display-modes-demo.form.spec.ts
+++ b/apps/examples-e2e/pages/display-modes-demo/display-modes-demo.form.spec.ts
@@ -24,6 +24,34 @@ test.describe('Display Modes Demo Form', () => {
     ).toHaveCount(1);
   });
 
+  test('should use the token-provided error mode for wrappers without overrides', async ({
+    page,
+  }) => {
+    const tokenDefaultError = page.getByLabel(/username \(token default error\)/i);
+    const tokenDefaultWrapper = tokenDefaultError.locator(
+      'xpath=ancestor::ngx-control-wrapper[1]'
+    );
+
+    await tokenDefaultError.focus();
+    await tokenDefaultError.blur();
+
+    await expect(
+      tokenDefaultWrapper.getByRole('status').filter({
+        hasText: /this field is required/i,
+      })
+    ).toHaveCount(0);
+
+    await page
+      .getByRole('button', { name: /programmatically submit demo form/i })
+      .click();
+
+    await expect(
+      tokenDefaultWrapper.getByRole('status').filter({
+        hasText: /this field is required/i,
+      })
+    ).toHaveCount(1);
+  });
+
   test('should show on-dirty error after typing in dirty error field', async ({
     page,
   }) => {
@@ -84,6 +112,33 @@ test.describe('Display Modes Demo Form', () => {
 
     await expect(
       alwaysWarningWrapper.getByRole('status').filter({
+        hasText: /username should be at least 5 characters/i,
+      })
+    ).toHaveCount(1);
+  });
+
+  test('should use the token-provided warning mode for wrappers without overrides', async ({
+    page,
+  }) => {
+    const tokenDefaultWarning = page.getByLabel(
+      /username \(token default warning\)/i
+    );
+    const tokenDefaultWrapper = tokenDefaultWarning.locator(
+      'xpath=ancestor::ngx-control-wrapper[1]'
+    );
+
+    await tokenDefaultWarning.fill('abc');
+
+    await expect(
+      tokenDefaultWrapper.getByRole('status').filter({
+        hasText: /username should be at least 5 characters/i,
+      })
+    ).toHaveCount(0);
+
+    await tokenDefaultWarning.blur();
+
+    await expect(
+      tokenDefaultWrapper.getByRole('status').filter({
         hasText: /username should be at least 5 characters/i,
       })
     ).toHaveCount(1);

--- a/apps/examples-e2e/pages/display-modes-demo/display-modes-demo.page.spec.ts
+++ b/apps/examples-e2e/pages/display-modes-demo/display-modes-demo.page.spec.ts
@@ -1,17 +1,18 @@
 import { expect, test } from '@playwright/test';
+import { getMainContentSidebar } from '../../helpers/form-helpers';
 
 test.describe('Display Modes Demo Page', () => {
   test('should render page layout and form-state sidebar', async ({ page }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await page.goto('/display-modes-demo');
 
     await expect(
       page.getByRole('heading', { name: /display modes demo/i, level: 1 })
     ).toBeVisible();
-    await expect(page.locator('aside')).toBeVisible();
-    await expect(page.locator('aside')).toContainText(/form value/i);
-    await expect(page.locator('aside')).toContainText(/form state/i);
-    await expect(
-      page.locator('aside span[aria-label="Pristine"]').first()
-    ).toBeVisible();
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar).toContainText(/form value/i);
+    await expect(sidebar).toContainText(/form state/i);
+    await expect(sidebar.locator('span[aria-label="Pristine"]').first()).toBeVisible();
   });
 });

--- a/apps/examples-e2e/pages/native-schema-demo/native-schema-demo.page.spec.ts
+++ b/apps/examples-e2e/pages/native-schema-demo/native-schema-demo.page.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { getMainContentSidebar } from '../../helpers/form-helpers';
 
 test.describe('Native Schema Demo Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -6,14 +7,14 @@ test.describe('Native Schema Demo Page', () => {
   });
 
   test('should render page layout and form-state sidebar', async ({ page }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await expect(
       page.getByRole('heading', { name: /Native Vest Schema Demo/i, level: 1 })
     ).toBeVisible();
-    await expect(page.locator('aside')).toBeVisible();
-    await expect(page.locator('aside')).toContainText(/form value/i);
-    await expect(page.locator('aside')).toContainText(/form state/i);
-    await expect(
-      page.locator('aside span[aria-label="Pristine"]').first()
-    ).toBeVisible();
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar).toContainText(/form value/i);
+    await expect(sidebar).toContainText(/form state/i);
+    await expect(sidebar.locator('span[aria-label="Pristine"]').first()).toBeVisible();
   });
 });

--- a/apps/examples-e2e/pages/purchase-form/purchase.form.tests.ts
+++ b/apps/examples-e2e/pages/purchase-form/purchase.form.tests.ts
@@ -803,7 +803,7 @@ test.describe('Purchase Form', () => {
             timeout: 5000,
           }
         );
-        await expect(fetchError).toContainText(/mock person 404 not found/i, {
+        await expect(fetchError).toContainText(/not found: person 404/i, {
           timeout: 5000,
         });
         await expect(userId).toBeEmpty();
@@ -1014,9 +1014,7 @@ test.describe('Purchase Form', () => {
             timeout: 5000,
           }
         );
-        await expect(fetchError).toContainText(
-          /mock server failed while loading person 1/i
-        );
+        await expect(fetchError).toContainText(/mock server failed: person 1/i);
       });
     });
 
@@ -1041,9 +1039,7 @@ test.describe('Purchase Form', () => {
             timeout: 5000,
           }
         );
-        await expect(fetchError).toContainText(
-          /you are not authorized to load mock person 1/i
-        );
+        await expect(fetchError).toContainText(/you are not authorized: person 1/i);
         await expect(fetchError).not.toContainText(
           /no person was found for this request/i
         );
@@ -1072,7 +1068,7 @@ test.describe('Purchase Form', () => {
           /we could not reach the people service/i
         );
         await expect(fetchError).toContainText(
-          /simulated network outage while contacting the mock people api/i
+          /simulated network outage while contacting the mock api \(person 1\)/i
         );
       });
     });

--- a/apps/examples-e2e/pages/purchase-form/purchase.page.spec.ts
+++ b/apps/examples-e2e/pages/purchase-form/purchase.page.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { navigateToPurchaseForm } from '../../helpers/form-helpers';
+import {
+  getMainContentSidebar,
+  navigateToPurchaseForm,
+} from '../../helpers/form-helpers';
 
 test.describe('Purchase Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -7,15 +10,15 @@ test.describe('Purchase Page', () => {
   });
 
   test('should render page layout and form-state sidebar', async ({ page }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await expect(
       page.getByRole('heading', { name: /purchase form/i, level: 1 })
     ).toBeVisible();
-    await expect(page.locator('aside')).toBeVisible();
-    await expect(page.locator('aside')).toContainText(/form value/i);
-    await expect(page.locator('aside')).toContainText(/form state/i);
-    await expect(
-      page.locator('aside span[aria-label="Pristine"]').first()
-    ).toBeVisible();
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar).toContainText(/form value/i);
+    await expect(sidebar).toContainText(/form state/i);
+    await expect(sidebar.locator('span[aria-label="Pristine"]').first()).toBeVisible();
     await expect(
       page.getByRole('button', { name: /fetch luke/i })
     ).toBeVisible();

--- a/apps/examples-e2e/pages/starter-form/starter.form.spec.ts
+++ b/apps/examples-e2e/pages/starter-form/starter.form.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from '@playwright/test';
+import { fillAndBlur, waitForValidationToSettle } from '../../helpers/form-helpers';
+
+test.describe('Starter Form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/starter');
+  });
+
+  test('should show validation errors on empty submit', async ({ page }) => {
+    await page.getByRole('button', { name: /send message/i }).click();
+    await waitForValidationToSettle(page);
+
+    const errorSummary = page.getByRole('alert').filter({
+      hasText: /name is required/i,
+    });
+
+    await expect(errorSummary).toContainText(/name is required/i);
+    await expect(errorSummary).toContainText(/email is required/i);
+    await expect(errorSummary).toContainText(/subject is required/i);
+    await expect(errorSummary).toContainText(/message is required/i);
+  });
+
+  test('should submit successfully and reset cleanly', async ({ page }) => {
+    const name = page.getByRole('textbox', { name: /^name$/i });
+    const email = page.getByRole('textbox', { name: /^email$/i });
+    const subject = page.getByRole('textbox', { name: /subject/i });
+    const message = page.getByRole('textbox', { name: /message/i });
+
+    await fillAndBlur(name, 'Ada Lovelace');
+    await fillAndBlur(email, 'ada@example.com');
+    await fillAndBlur(subject, 'Validation help');
+    await fillAndBlur(
+      message,
+      'We need help wiring template-driven validation with Vest.'
+    );
+
+    await page.getByRole('button', { name: /send message/i }).click();
+
+    await expect(
+      page.getByRole('status').filter({ hasText: /message sent/i })
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: /reset/i }).click();
+    await expect(name).toHaveValue('');
+    await expect(email).toHaveValue('');
+    await expect(subject).toHaveValue('');
+    await expect(message).toHaveValue('');
+  });
+});

--- a/apps/examples-e2e/pages/starter-form/starter.page.spec.ts
+++ b/apps/examples-e2e/pages/starter-form/starter.page.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Starter Form Page', () => {
+  test('should render the starter demo shell', async ({ page }) => {
+    await page.goto('/starter');
+
+    await expect(
+      page.getByRole('heading', { name: /starter contact form/i, level: 1 })
+    ).toBeVisible();
+    await expect(page.getByRole('textbox', { name: /^name$/i })).toBeVisible();
+    await expect(page.getByRole('textbox', { name: /^email$/i })).toBeVisible();
+    await expect(page.getByRole('textbox', { name: /subject/i })).toBeVisible();
+    await expect(page.getByRole('textbox', { name: /message/i })).toBeVisible();
+  });
+});

--- a/apps/examples-e2e/pages/submission-patterns-form/submission-patterns.form.spec.ts
+++ b/apps/examples-e2e/pages/submission-patterns-form/submission-patterns.form.spec.ts
@@ -27,6 +27,37 @@ test.describe('Submission Patterns Form', () => {
     ).toBeVisible();
   });
 
+  test('should clear the submit cycle without resetting current values', async ({
+    page,
+  }) => {
+    const fullName = page.getByLabel('Full name', { exact: true });
+    const email = page.getByLabel('Email', { exact: true });
+    const emailWrapper = email.locator('xpath=ancestor::ngx-control-wrapper[1]');
+    const clearSubmittedState = page.getByRole('button', {
+      name: /clear submitted state/i,
+    });
+    const errorSummary = page.getByRole('alert').filter({
+      hasText: /email is required/i,
+    });
+
+    await fillAndBlur(fullName, 'Ada Lovelace');
+    await page.getByRole('button', { name: /create account/i }).click();
+    await waitForValidationToSettle(page);
+
+    await expect(clearSubmittedState).toBeVisible();
+    await expect(errorSummary).toContainText(/email is required/i);
+
+    await clearSubmittedState.click();
+
+    await expect(clearSubmittedState).toHaveCount(0);
+    await expect(fullName).toHaveValue('Ada Lovelace');
+    await expect(
+      emailWrapper.getByRole('status').filter({
+        hasText: /email is required/i,
+      })
+    ).toHaveCount(0);
+  });
+
   test('should retry a server failure and reach the success state', async ({
     page,
   }) => {

--- a/apps/examples-e2e/pages/submission-patterns-form/submission-patterns.form.spec.ts
+++ b/apps/examples-e2e/pages/submission-patterns-form/submission-patterns.form.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+import {
+  fillAndBlur,
+  waitForValidationToSettle,
+} from '../../helpers/form-helpers';
+
+test.describe('Submission Patterns Form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/submission-patterns', { waitUntil: 'domcontentloaded' });
+  });
+
+  test('should focus the first invalid field when submitted empty', async ({
+    page,
+  }) => {
+    const fullName = page.getByLabel('Full name', { exact: true });
+    const submitButton = page.getByRole('button', { name: /create account/i });
+
+    await submitButton.click();
+    await waitForValidationToSettle(page);
+
+    await expect(fullName).toBeFocused();
+    await expect(
+      page.getByRole('alert').filter({ hasText: /errors/i })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('alert').getByText(/full name is required/i)
+    ).toBeVisible();
+  });
+
+  test('should retry a server failure and reach the success state', async ({
+    page,
+  }) => {
+    const fullName = page.getByLabel('Full name', { exact: true });
+    const email = page.getByLabel('Email', { exact: true });
+    const password = page.getByLabel('Password', { exact: true });
+    const acceptTerms = page.getByLabel('I accept the terms of service', {
+      exact: true,
+    });
+    const serverResponse = page.getByRole('combobox', {
+      name: /server response/i,
+    });
+
+    await fillAndBlur(fullName, 'Ada Lovelace');
+    await fillAndBlur(email, 'ada@example.com');
+    await fillAndBlur(password, 'password123456');
+    await acceptTerms.check();
+
+    await serverResponse.selectOption('Email already taken (409)');
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    const serverErrorAlert = page
+      .getByRole('alert')
+      .filter({ hasText: /couldn't create your account/i });
+    await expect(serverErrorAlert).toBeVisible();
+    await expect(page.getByRole('button', { name: /retry/i })).toBeVisible();
+
+    await serverResponse.selectOption('Normal — succeeds (201)');
+    await page.getByRole('button', { name: /retry/i }).click();
+
+    const successAlert = page
+      .getByRole('status')
+      .filter({ hasText: /account created/i });
+    await expect(successAlert).toBeVisible();
+    await expect(successAlert).toContainText(/acct_/i);
+
+    await page.getByRole('button', { name: /create another/i }).click();
+    await expect(fullName).toHaveValue('');
+    await expect(email).toHaveValue('');
+    await expect(password).toHaveValue('');
+    await expect(acceptTerms).not.toBeChecked();
+  });
+});

--- a/apps/examples-e2e/pages/submission-patterns-form/submission-patterns.page.spec.ts
+++ b/apps/examples-e2e/pages/submission-patterns-form/submission-patterns.page.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Submission Patterns Page', () => {
+  test('should render the submission-state demo layout', async ({ page }) => {
+    await page.goto('/submission-patterns', { waitUntil: 'domcontentloaded' });
+
+    await expect(
+      page.getByRole('heading', {
+        name: /submission patterns/i,
+        level: 1,
+      })
+    ).toBeVisible();
+
+    const contentAside = page
+      .getByRole('complementary')
+      .filter({ hasText: /simulated outcome/i });
+    await expect(contentAside).toBeVisible();
+    await expect(contentAside).toContainText(/form state/i);
+    await expect(contentAside).toContainText(/form value/i);
+
+    await expect(page.getByLabel(/server response/i)).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /create account/i })
+    ).toBeVisible();
+  });
+});

--- a/apps/examples-e2e/pages/validation-config-demo/validation-config-demo.form.tests.ts
+++ b/apps/examples-e2e/pages/validation-config-demo/validation-config-demo.form.tests.ts
@@ -1334,18 +1334,36 @@ test.describe('ValidationConfig Demo', () => {
       page,
     }) => {
       await test.step('Verify all sections are visible', async () => {
-        // Look for section headings
         await expect(
-          page.locator('text=/bidirectional.*password/i')
+          page.getByRole('heading', {
+            name: /bidirectional validation/i,
+            level: 2,
+          })
         ).toBeVisible();
         await expect(
-          page.locator('text=/cross-field.*requirement/i')
+          page.getByRole('heading', {
+            name: /cross-field requirement/i,
+            level: 2,
+          })
         ).toBeVisible();
         await expect(
-          page.locator('text=/conditional.*justification/i')
+          page.getByRole('heading', {
+            name: /conditional validation/i,
+            level: 2,
+          })
         ).toBeVisible();
-        await expect(page.locator('text=/cascade.*country/i')).toBeVisible();
-        await expect(page.locator('text=/date range/i')).toBeVisible();
+        await expect(
+          page.getByRole('heading', {
+            name: /cascade validation/i,
+            level: 2,
+          })
+        ).toBeVisible();
+        await expect(
+          page.getByRole('heading', {
+            name: /date range validation/i,
+            level: 2,
+          })
+        ).toBeVisible();
       });
     });
 

--- a/apps/examples-e2e/pages/validation-config-demo/validation-config-demo.page.spec.ts
+++ b/apps/examples-e2e/pages/validation-config-demo/validation-config-demo.page.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
-import { navigateToValidationConfigDemo } from '../../helpers/form-helpers';
+import {
+  getMainContentSidebar,
+  navigateToValidationConfigDemo,
+} from '../../helpers/form-helpers';
 
 test.describe('Validation Config Demo Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -7,17 +10,27 @@ test.describe('Validation Config Demo Page', () => {
   });
 
   test('should render page layout and key sections', async ({ page }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await expect(
       page.getByRole('heading', { name: /validation config demo/i, level: 1 })
     ).toBeVisible();
-    await expect(page.locator('aside')).toBeVisible();
-    await expect(page.locator('aside')).toContainText(/form value/i);
-    await expect(page.locator('aside')).toContainText(/form state/i);
-    await expect(
-      page.locator('aside span[aria-label="Pristine"]').first()
-    ).toBeVisible();
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar).toContainText(/form value/i);
+    await expect(sidebar).toContainText(/form state/i);
+    await expect(sidebar.locator('span[aria-label="Pristine"]').first()).toBeVisible();
 
-    await expect(page.locator('text=/bidirectional.*password/i')).toBeVisible();
-    await expect(page.locator('text=/date range/i')).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: /bidirectional validation/i,
+        level: 2,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', {
+        name: /date range validation/i,
+        level: 2,
+      })
+    ).toBeVisible();
   });
 });

--- a/apps/examples-e2e/pages/wizard-form/wizard-form.page.spec.ts
+++ b/apps/examples-e2e/pages/wizard-form/wizard-form.page.spec.ts
@@ -1,9 +1,12 @@
 import { expect, test } from '@playwright/test';
+import { getMainContentSidebar } from '../../helpers/form-helpers';
 
 test.describe('Wizard Form Page', () => {
   test('should render wizard page layout and step navigation', async ({
     page,
   }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await page.goto('/wizard');
 
     await expect(
@@ -11,10 +14,8 @@ test.describe('Wizard Form Page', () => {
     ).toBeVisible();
 
     await expect(page.locator('ngx-wizard-steps nav')).toBeVisible();
-    await expect(page.locator('aside').first()).toBeVisible();
-    await expect(page.locator('aside').first()).toContainText(/form value/i);
-    await expect(
-      page.locator('aside span[aria-label="Pristine"]').first()
-    ).toBeVisible();
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar).toContainText(/form value/i);
+    await expect(sidebar.locator('span[aria-label="Pristine"]').first()).toBeVisible();
   });
 });

--- a/apps/examples-e2e/pages/zod-schema-demo/zod-schema-demo.page.spec.ts
+++ b/apps/examples-e2e/pages/zod-schema-demo/zod-schema-demo.page.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { getMainContentSidebar } from '../../helpers/form-helpers';
 
 test.describe('Zod Schema Demo Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -6,14 +7,14 @@ test.describe('Zod Schema Demo Page', () => {
   });
 
   test('should render page layout and form-state sidebar', async ({ page }) => {
+    const sidebar = getMainContentSidebar(page);
+
     await expect(
       page.getByRole('heading', { name: /Zod Schema Demo/i, level: 1 })
     ).toBeVisible();
-    await expect(page.locator('aside')).toBeVisible();
-    await expect(page.locator('aside')).toContainText(/form value/i);
-    await expect(page.locator('aside')).toContainText(/form state/i);
-    await expect(
-      page.locator('aside span[aria-label="Pristine"]').first()
-    ).toBeVisible();
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar).toContainText(/form value/i);
+    await expect(sidebar).toContainText(/form state/i);
+    await expect(sidebar.locator('span[aria-label="Pristine"]').first()).toBeVisible();
   });
 });

--- a/apps/examples/src/app/app.component.html
+++ b/apps/examples/src/app/app.component.html
@@ -1,36 +1,138 @@
-<a href="#main-content" class="sr-only focus:not-sr-only"
-  >Skip to main content</a
->
-<nav
-  class="border-b border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
->
-  <div class="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
-    <ul class="flex gap-6">
-      @for (item of menuItems; track item.link) {
-        <li>
-          <a
-            routerLinkActive
-            #activeLink="routerLinkActive"
-            [routerLink]="item.link"
-            [routerLinkActiveOptions]="{
-              paths: 'subset',
-              queryParams: 'ignored',
-              fragment: 'ignored',
-              matrixParams: 'ignored',
-            }"
-            [class]="
-              activeLink.isActive
-                ? 'font-semibold text-blue-600 dark:text-blue-500'
-                : 'text-gray-700 hover:text-blue-600 dark:text-gray-300 dark:hover:text-blue-500'
-            "
-            >{{ item.label }}</a
-          >
-        </li>
-      }
-    </ul>
+<a href="#main-content" class="sr-only focus:not-sr-only">Skip to main content</a>
+
+<div class="lg:flex lg:min-h-screen">
+  <!-- Mobile top bar -->
+  <header
+    class="sticky top-0 z-30 flex items-center justify-between border-b border-gray-200/70 bg-white/80 px-4 py-3 backdrop-blur-md lg:hidden dark:border-gray-700/70 dark:bg-gray-900/80"
+  >
+    <button
+      type="button"
+      class="btn btn-secondary !px-3 !py-2"
+      [attr.aria-expanded]="drawerOpen()"
+      aria-controls="app-sidebar"
+      aria-label="Toggle navigation"
+      (click)="toggleDrawer()"
+    >
+      <svg class="size-5" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path
+          d="M4 6h16M4 12h16M4 18h16"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+        />
+      </svg>
+    </button>
+    <span class="font-mono text-sm font-semibold tracking-tight">
+      ngx-vest-forms
+    </span>
     <ngx-theme-switcher />
-  </div>
-</nav>
-<main id="main-content">
-  <router-outlet></router-outlet>
-</main>
+  </header>
+
+  <!-- Backdrop (mobile, when drawer open) -->
+  @if (drawerOpen()) {
+    <button
+      type="button"
+      class="fixed inset-0 z-30 bg-gray-900/40 backdrop-blur-[2px] lg:hidden"
+      aria-label="Close navigation"
+      (click)="closeDrawer()"
+    ></button>
+  }
+
+  <!-- Sidebar -->
+  <aside
+    id="app-sidebar"
+    class="fixed inset-y-0 left-0 z-40 flex w-72 -translate-x-full flex-col border-r border-gray-200/70 bg-white/95 transition-transform duration-300 ease-out lg:sticky lg:top-0 lg:z-0 lg:h-screen lg:translate-x-0 lg:bg-white/60 lg:backdrop-blur-xl dark:border-gray-700/70 dark:bg-gray-900/95 lg:dark:bg-gray-900/50"
+    [class.translate-x-0]="drawerOpen()"
+  >
+    <div class="border-b border-gray-200/70 px-6 py-6 dark:border-gray-700/70">
+      <p
+        class="font-mono text-base font-semibold tracking-tight text-gray-950 dark:text-gray-50"
+      >
+        ngx-vest-forms
+      </p>
+      <p
+        class="text-primary-700 dark:text-primary-400 mt-0.5 text-xs font-medium tracking-[0.2em] uppercase"
+      >
+        Examples
+      </p>
+    </div>
+
+    <nav
+      class="flex-1 overflow-y-auto px-3 py-5"
+      aria-label="Demo navigation"
+    >
+      @for (group of navGroups; track group.category; let g = $index) {
+        <div
+          class="mb-6 motion-safe:animate-[fade-in-up_0.4s_ease-out_both]"
+          [style.animation-delay.ms]="g * 60"
+        >
+          <h2
+            class="px-3 pb-2 text-[0.7rem] font-semibold tracking-[0.18em] text-gray-400 uppercase dark:text-gray-500"
+          >
+            {{ group.category }}
+          </h2>
+          <ul class="space-y-0.5">
+            @for (item of group.items; track item.path) {
+              <li>
+                <a
+                  routerLinkActive
+                  #rla="routerLinkActive"
+                  [routerLink]="['/', item.path]"
+                  [routerLinkActiveOptions]="{
+                    paths: 'subset',
+                    queryParams: 'ignored',
+                    fragment: 'ignored',
+                    matrixParams: 'ignored',
+                  }"
+                  [attr.aria-current]="rla.isActive ? 'page' : null"
+                  class="group flex items-center justify-between gap-2 rounded-lg px-3 py-2 text-sm transition-colors"
+                  [class]="
+                    rla.isActive
+                      ? 'bg-primary-50 font-semibold text-primary-800 dark:bg-primary-900/30 dark:text-primary-200'
+                      : 'text-gray-600 hover:bg-gray-100/70 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-800/60 dark:hover:text-white'
+                  "
+                >
+                  <span class="flex items-center gap-2">
+                    <span
+                      class="h-4 w-0.5 rounded-full transition-colors"
+                      [class]="
+                        rla.isActive
+                          ? 'bg-primary-600 dark:bg-primary-400'
+                          : 'bg-transparent group-hover:bg-gray-300 dark:group-hover:bg-gray-600'
+                      "
+                      aria-hidden="true"
+                    ></span>
+                    {{ item.label }}
+                  </span>
+                  @if (item.badge === 'start-here') {
+                    <span
+                      class="bg-primary-600 rounded-full px-1.5 py-0.5 text-[0.6rem] font-semibold tracking-wide text-white uppercase"
+                      >Start</span
+                    >
+                  } @else if (item.badge === 'new') {
+                    <span
+                      class="rounded-full bg-amber-100 px-1.5 py-0.5 text-[0.6rem] font-semibold tracking-wide text-amber-700 uppercase dark:bg-amber-900/40 dark:text-amber-300"
+                      >New</span
+                    >
+                  }
+                </a>
+              </li>
+            }
+          </ul>
+        </div>
+      }
+    </nav>
+
+    <div
+      class="hidden items-center justify-between border-t border-gray-200/70 px-6 py-4 lg:flex dark:border-gray-700/70"
+    >
+      <span class="text-xs text-gray-400 dark:text-gray-500">Theme</span>
+      <ngx-theme-switcher />
+    </div>
+  </aside>
+
+  <!-- Main content -->
+  <main id="main-content" class="min-w-0 flex-1">
+    <router-outlet />
+  </main>
+</div>

--- a/apps/examples/src/app/app.component.html
+++ b/apps/examples/src/app/app.component.html
@@ -6,6 +6,7 @@
     class="sticky top-0 z-30 flex items-center justify-between border-b border-gray-200/70 bg-white/80 px-4 py-3 backdrop-blur-md lg:hidden dark:border-gray-700/70 dark:bg-gray-900/80"
   >
     <button
+      #menuToggle
       type="button"
       class="btn btn-secondary !px-3 !py-2"
       [attr.aria-expanded]="drawerOpen()"
@@ -40,9 +41,13 @@
 
   <!-- Sidebar -->
   <aside
+    #sidebar
     id="app-sidebar"
+    tabindex="-1"
     class="fixed inset-y-0 left-0 z-40 flex w-72 -translate-x-full flex-col border-r border-gray-200/70 bg-white/95 transition-transform duration-300 ease-out lg:sticky lg:top-0 lg:z-0 lg:h-screen lg:translate-x-0 lg:bg-white/60 lg:backdrop-blur-xl dark:border-gray-700/70 dark:bg-gray-900/95 lg:dark:bg-gray-900/50"
     [class.translate-x-0]="drawerOpen()"
+    [inert]="!isDesktop() && !drawerOpen()"
+    (keydown.escape)="closeDrawer()"
   >
     <div class="border-b border-gray-200/70 px-6 py-6 dark:border-gray-700/70">
       <p

--- a/apps/examples/src/app/app.component.ts
+++ b/apps/examples/src/app/app.component.ts
@@ -1,7 +1,28 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  NavigationEnd,
+  Router,
+  RouterLink,
+  RouterLinkActive,
+  RouterOutlet,
+} from '@angular/router';
+import { filter } from 'rxjs';
+import { buildNavGroups } from './shared/routes.metadata';
 import { ThemeSwitcherComponent } from './ui/theme-switcher/theme-switcher.component';
 
+/**
+ * Examples App shell.
+ *
+ * The categorized sidebar is rendered entirely from {@link buildNavGroups} —
+ * re-grouping or adding a demo is a data change in `routes.metadata.ts`, never
+ * a template change here.
+ */
 @Component({
   selector: 'ngx-root',
   imports: [RouterLink, RouterLinkActive, RouterOutlet, ThemeSwitcherComponent],
@@ -10,17 +31,26 @@ import { ThemeSwitcherComponent } from './ui/theme-switcher/theme-switcher.compo
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
-  title = 'purchase';
+  protected readonly navGroups = buildNavGroups();
 
-  protected readonly menuItems = [
-    { label: 'Purchase Form', link: 'purchase' },
-    { label: 'Business Hours Form', link: 'business-hours' },
-    { label: 'Validation Config Demo', link: 'validation-config-demo' },
-    { label: 'Auto-Save Draft Demo', link: 'auto-save-demo' },
-    { label: 'Multi-Form Wizard', link: 'wizard' },
-    { label: 'Display Modes Demo', link: 'display-modes-demo' },
-    { label: 'Native Schema Demo', link: 'native-schema-demo' },
-    { label: 'Zod Schema Demo', link: 'zod-schema-demo' },
-    { label: 'Composite Adapter', link: 'date-range-adapter' },
-  ];
+  /** Mobile drawer visibility; ignored at `lg` breakpoint and above. */
+  protected readonly drawerOpen = signal(false);
+
+  constructor() {
+    // Close the mobile drawer whenever navigation completes.
+    inject(Router)
+      .events.pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntilDestroyed()
+      )
+      .subscribe(() => this.drawerOpen.set(false));
+  }
+
+  protected toggleDrawer(): void {
+    this.drawerOpen.update((open) => !open);
+  }
+
+  protected closeDrawer(): void {
+    this.drawerOpen.set(false);
+  }
 }

--- a/apps/examples/src/app/app.component.ts
+++ b/apps/examples/src/app/app.component.ts
@@ -1,8 +1,11 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  effect,
+  ElementRef,
   inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
@@ -36,6 +39,22 @@ export class AppComponent {
   /** Mobile drawer visibility; ignored at `lg` breakpoint and above. */
   protected readonly drawerOpen = signal(false);
 
+  /**
+   * Tracks the `lg` breakpoint. At desktop the sidebar is always visible and
+   * interactive regardless of {@link drawerOpen}; below it the off-canvas
+   * drawer must be made `inert` when closed so keyboard users don't tab into
+   * hidden links.
+   */
+  protected readonly isDesktop = signal(true);
+
+  private readonly sidebar =
+    viewChild<ElementRef<HTMLElement>>('sidebar');
+  private readonly menuToggle =
+    viewChild<ElementRef<HTMLElement>>('menuToggle');
+
+  /** Previous drawer state, used to drive focus only on actual transitions. */
+  private wasOpen = false;
+
   constructor() {
     // Close the mobile drawer whenever navigation completes.
     inject(Router)
@@ -44,6 +63,33 @@ export class AppComponent {
         takeUntilDestroyed()
       )
       .subscribe(() => this.drawerOpen.set(false));
+
+    const media = globalThis.matchMedia?.('(min-width: 1024px)');
+    if (media) {
+      this.isDesktop.set(media.matches);
+      media.addEventListener('change', (event) =>
+        this.isDesktop.set(event.matches)
+      );
+    }
+
+    // Mobile drawer focus management: move focus into the drawer on open,
+    // return it to the toggle on close. Skipped entirely at desktop where the
+    // sidebar is persistent.
+    effect(() => {
+      const open = this.drawerOpen();
+      if (this.isDesktop()) {
+        this.wasOpen = open;
+        return;
+      }
+      if (open && !this.wasOpen) {
+        this.sidebar()
+          ?.nativeElement.querySelector<HTMLElement>('a[routerLink]')
+          ?.focus();
+      } else if (!open && this.wasOpen) {
+        this.menuToggle()?.nativeElement.focus();
+      }
+      this.wasOpen = open;
+    });
   }
 
   protected toggleDrawer(): void {

--- a/apps/examples/src/app/models/accessible-wrapper.model.ts
+++ b/apps/examples/src/app/models/accessible-wrapper.model.ts
@@ -1,0 +1,11 @@
+import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
+
+export type AccessibleWrapperModel = NgxDeepPartial<{
+  preferredName: string;
+  searchQuery: string;
+}>;
+
+export const accessibleWrapperContract: NgxDeepRequired<AccessibleWrapperModel> = {
+  preferredName: '',
+  searchQuery: '',
+};

--- a/apps/examples/src/app/models/async-username.model.ts
+++ b/apps/examples/src/app/models/async-username.model.ts
@@ -1,0 +1,23 @@
+import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
+
+/**
+ * Model for the Async Username Availability demo.
+ *
+ * `NgxDeepPartial` is the recommended shape for ngx-vest-forms models — every
+ * field is optional because the template owns the truth and fields populate
+ * progressively as the user types.
+ */
+export type AsyncUsernameModel = NgxDeepPartial<{
+  username: string;
+  displayName: string;
+}>;
+
+/**
+ * The form contract: the fully-required mirror of the model. Providing it via
+ * `provideFormContract` lets ngx-vest-forms warn (in dev) about `name`
+ * attributes that don't line up with the model shape.
+ */
+export const asyncUsernameShape: NgxDeepRequired<AsyncUsernameModel> = {
+  username: '',
+  displayName: '',
+};

--- a/apps/examples/src/app/models/business-policy.model.ts
+++ b/apps/examples/src/app/models/business-policy.model.ts
@@ -1,0 +1,34 @@
+import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
+
+/**
+ * A business account application.
+ *
+ * `NgxDeepPartial` keeps every field optional — the template owns the truth and
+ * fields populate progressively. The interesting bit is the policy layer in
+ * `business-policy.validations.ts`: most rules are conditional and several are
+ * advisory-only `warn()` checks that never block submit.
+ */
+export type BusinessPolicyModel = NgxDeepPartial<{
+  accountType: 'personal' | 'business';
+  legalName: string;
+  country: string;
+  vatId: string;
+  annualRevenue: number;
+  requestedCreditLimit: number;
+  paymentTermsDays: number;
+}>;
+
+/**
+ * The form contract: the fully-required mirror of the model. Providing it via
+ * `provideFormContract` lets ngx-vest-forms warn (in dev) about `name`
+ * attributes that don't line up with the model shape.
+ */
+export const businessPolicyContract: NgxDeepRequired<BusinessPolicyModel> = {
+  accountType: 'personal',
+  legalName: '',
+  country: '',
+  vatId: '',
+  annualRevenue: 0,
+  requestedCreditLimit: 0,
+  paymentTermsDays: 0,
+};

--- a/apps/examples/src/app/models/complex-nested.model.ts
+++ b/apps/examples/src/app/models/complex-nested.model.ts
@@ -1,0 +1,66 @@
+import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
+import { AddressModel, addressContract } from './address.model';
+
+/** A single team member entry inside the keyed `teamMembers` record. */
+export type TeamMemberModel = {
+  fullName: string;
+  email: string;
+  role: string;
+};
+
+/**
+ * Team registration form.
+ *
+ * - `company` is a nested `ngModelGroup` containing a name plus a deeply
+ *   nested `address` group rendered by the reusable `ngx-address`.
+ * - `teamMembers` is a dynamic, repeatable collection stored as a record
+ *   keyed by a stable id (mirrors the purchase form's keyed-record pattern
+ *   so Vest field paths stay stable across add/remove).
+ */
+export type ComplexNestedModel = NgxDeepPartial<{
+  company: {
+    name: string;
+    address: AddressModel;
+  };
+  teamMembers: Record<string, TeamMemberModel>;
+}>;
+
+/**
+ * Form contract (NgxDeepRequired) mirroring the model shape. The record uses a
+ * single representative key so the directive can validate `name` attributes
+ * against the expected nested structure (same approach as
+ * `phoneNumberContract` in purchase-form.model.ts).
+ */
+export const complexNestedContract: NgxDeepRequired<ComplexNestedModel> = {
+  company: {
+    name: '',
+    address: addressContract,
+  },
+  teamMembers: {
+    '0': {
+      fullName: '',
+      email: '',
+      role: '',
+    },
+  },
+};
+
+export const initialComplexNestedValue: ComplexNestedModel = {
+  company: {
+    name: '',
+    address: {
+      street: '',
+      number: '',
+      city: '',
+      zipcode: '',
+      country: '',
+    },
+  },
+  teamMembers: {
+    '0': {
+      fullName: '',
+      email: '',
+      role: '',
+    },
+  },
+};

--- a/apps/examples/src/app/models/conditional-structure.model.ts
+++ b/apps/examples/src/app/models/conditional-structure.model.ts
@@ -1,0 +1,21 @@
+import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
+
+export type DeliveryMode = 'pickup' | 'shipment' | 'digital';
+
+export type ConditionalStructureModel = NgxDeepPartial<{
+  contactName: string;
+  deliveryMode: DeliveryMode;
+  shippingAddress: string;
+  deliveryEmail: string;
+}>;
+
+export const conditionalStructureContract: NgxDeepRequired<ConditionalStructureModel> = {
+  contactName: '',
+  deliveryMode: 'pickup',
+  shippingAddress: '',
+  deliveryEmail: '',
+};
+
+export const initialConditionalStructureValue: ConditionalStructureModel = {
+  deliveryMode: 'pickup',
+};

--- a/apps/examples/src/app/models/custom-controls.model.ts
+++ b/apps/examples/src/app/models/custom-controls.model.ts
@@ -1,0 +1,28 @@
+import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
+
+/**
+ * Model for the Custom Controls demo.
+ *
+ * Every value here is produced by a non-native control built on Angular's
+ * `ControlValueAccessor`, yet the model shape is identical to what a native
+ * input form would use — `NgxDeepPartial` because the template owns the truth.
+ */
+export type CustomControlsModel = NgxDeepPartial<{
+  /** 1–5 star rating, emitted by `ngx-star-rating`. */
+  rating: number;
+  /** Single-select experience level, emitted by `ngx-segmented-control`. */
+  experience: string;
+  /** Free-form tags, emitted by `ngx-tag-input`. */
+  tags: string[];
+}>;
+
+/**
+ * The fully-required mirror of {@link CustomControlsModel}. Supplied via
+ * `provideFormContract` so ngx-vest-forms can warn (in dev) when a `name`
+ * attribute drifts from the model — exactly as with native inputs.
+ */
+export const customControlsContract: NgxDeepRequired<CustomControlsModel> = {
+  rating: 0,
+  experience: '',
+  tags: [],
+};

--- a/apps/examples/src/app/models/display-modes-demo.model.ts
+++ b/apps/examples/src/app/models/display-modes-demo.model.ts
@@ -1,6 +1,8 @@
 import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
 
 export type DisplayModesDemoModel = NgxDeepPartial<{
+  tokenDefaultError: string;
+  tokenDefaultWarning: string;
   alwaysError: string;
   dirtyError: string;
   submitError: string;
@@ -10,6 +12,8 @@ export type DisplayModesDemoModel = NgxDeepPartial<{
 }>;
 
 export const displayModesDemoContract: NgxDeepRequired<DisplayModesDemoModel> = {
+  tokenDefaultError: '',
+  tokenDefaultWarning: '',
   alwaysError: '',
   dirtyError: '',
   submitError: '',

--- a/apps/examples/src/app/models/starter-form.model.ts
+++ b/apps/examples/src/app/models/starter-form.model.ts
@@ -1,0 +1,27 @@
+import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
+
+/**
+ * The canonical starter model: a small, opinionated contact form.
+ *
+ * `NgxDeepPartial` is the recommended shape for ngx-vest-forms models — every
+ * field is optional because the template owns the truth and fields populate
+ * progressively as the user types.
+ */
+export type StarterFormModel = NgxDeepPartial<{
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}>;
+
+/**
+ * The form contract: the fully-required mirror of the model. Providing it via
+ * `provideFormContract` lets ngx-vest-forms warn (in dev) about `name`
+ * attributes that don't line up with the model shape.
+ */
+export const starterFormShape: NgxDeepRequired<StarterFormModel> = {
+  name: '',
+  email: '',
+  subject: '',
+  message: '',
+};

--- a/apps/examples/src/app/models/submission-patterns.model.ts
+++ b/apps/examples/src/app/models/submission-patterns.model.ts
@@ -1,0 +1,28 @@
+import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';
+
+/**
+ * The account-creation model for the Submission Patterns demo.
+ *
+ * `NgxDeepPartial` is the recommended shape for ngx-vest-forms models — every
+ * field is optional because the template owns the truth and fields populate
+ * progressively as the user types.
+ */
+export type SubmissionPatternsModel = NgxDeepPartial<{
+  fullName: string;
+  email: string;
+  password: string;
+  acceptTerms: boolean;
+}>;
+
+/**
+ * The form contract: the fully-required mirror of the model. Providing it via
+ * `provideFormContract` lets ngx-vest-forms warn (in dev) about `name`
+ * attributes that don't line up with the model shape.
+ */
+export const submissionPatternsShape: NgxDeepRequired<SubmissionPatternsModel> =
+  {
+    fullName: '',
+    email: '',
+    password: '',
+    acceptTerms: false,
+  };

--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.content.ts
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.content.ts
@@ -1,0 +1,35 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const accessibleWrapperContent = defineExampleContent({
+  demonstrates: {
+    icon: '♿',
+    title: 'What this demonstrates',
+    points: [
+      'FormErrorControlDirective gives custom wrappers the same error/warning/pending IDs and ARIA helpers as the built-in wrappers.',
+      'ariaAssociationMode="single-control" merges generated error IDs into one existing aria-describedby chain automatically.',
+      'ariaAssociationMode="none" lets multi-control wrappers opt out of automatic stamping and wire the relevant input manually.',
+      'Inline error regions stay in the DOM with stable IDs, so manual aria-describedby wiring remains predictable.',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Directive-based wrapper ergonomics',
+        points: [
+          'Use ngxErrorControl when you need custom markup but still want packaged state and generated region IDs.',
+          'Pick ariaAssociationMode based on how many actual form controls live inside the wrapper.',
+          'Keep hints in aria-describedby and let the directive merge its own IDs when appropriate.',
+        ],
+      },
+      {
+        title: 'Manual ARIA ownership',
+        points: [
+          'For mixed wrappers (for example an input plus a button), wire aria-describedby and aria-invalid only to the real form control.',
+          'Do not leak validation state onto adjacent helper buttons or static content.',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Custom controls', route: 'custom-controls' },
+  },
+});

--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.form.html
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.form.html
@@ -1,0 +1,104 @@
+<form
+  ngxVestForm
+  #vestForm="ngxVestForm"
+  [suite]="suite()"
+  [formValue]="formValue()"
+  (formValueChange)="formValueChange.emit($event)"
+  (ngSubmit)="onSubmit()"
+  class="space-y-6"
+>
+  <div
+    ngxErrorControl
+    #preferredControl="ngxErrorControl"
+    ariaAssociationMode="single-control"
+    class="rounded-2xl border border-gray-200 bg-white p-4 shadow-xs dark:border-gray-700 dark:bg-gray-900"
+  >
+    <label for="preferredName" class="label-text">Preferred name</label>
+    <p
+      id="preferred-name-hint"
+      class="mt-1 text-sm text-gray-600 dark:text-gray-300"
+    >
+      This field already has a static hint. The directive appends its
+      validation region automatically when errors appear.
+    </p>
+    <input
+      class="input-field mt-3"
+      type="text"
+      id="preferredName"
+      name="preferredName"
+      [ngModel]="formValue().preferredName"
+      autocomplete="nickname"
+      aria-describedby="preferred-name-hint"
+      placeholder="How should we address you?"
+    />
+    <div
+      [id]="preferredControl.errorId"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      class="mt-3 text-sm text-red-700 dark:text-red-300"
+    >
+      @if (shouldShowErrors(preferredControl)) {
+        @for (message of controlErrors(preferredControl); track message) {
+          <p>{{ message }}</p>
+        }
+      }
+    </div>
+  </div>
+
+  <div
+    ngxErrorControl
+    #searchControl="ngxErrorControl"
+    ariaAssociationMode="none"
+    class="rounded-2xl border border-gray-200 bg-white p-4 shadow-xs dark:border-gray-700 dark:bg-gray-900"
+  >
+    <label for="searchQuery" class="label-text">Search query</label>
+    <p
+      id="search-query-hint"
+      class="mt-1 text-sm text-gray-600 dark:text-gray-300"
+    >
+      This wrapper contains both the real input and a helper button, so the
+      input owns the validation wiring manually.
+    </p>
+    <div class="mt-3 flex flex-wrap items-start gap-3">
+      <input
+        class="input-field min-w-0 flex-1"
+        type="search"
+        id="searchQuery"
+        name="searchQuery"
+        [ngModel]="formValue().searchQuery"
+        [attr.aria-describedby]="'search-query-hint ' + searchControl.errorId"
+        [attr.aria-invalid]="shouldShowErrors(searchControl) ? 'true' : null"
+        autocomplete="off"
+        placeholder="Search examples, docs, or issues"
+      />
+      <button
+        type="button"
+        class="btn btn-secondary"
+        (click)="clearSearchRequested.emit()"
+      >
+        Clear search query
+      </button>
+    </div>
+    <div
+      [id]="searchControl.errorId"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      class="mt-3 text-sm text-red-700 dark:text-red-300"
+    >
+      @if (shouldShowErrors(searchControl)) {
+        @for (message of controlErrors(searchControl); track message) {
+          <p>{{ message }}</p>
+        }
+      }
+    </div>
+  </div>
+
+  <div class="flex justify-end gap-3 pt-2">
+    <button type="button" class="btn btn-secondary" (click)="onReset()">
+      Reset
+    </button>
+    <button type="submit" class="btn btn-primary">Save preferences</button>
+  </div>
+</form>

--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.form.ts
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.form.ts
@@ -1,0 +1,65 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  FormErrorControlDirective,
+  NgxVestForms,
+  NgxVestSuite,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  AccessibleWrapperModel,
+  accessibleWrapperContract,
+} from '../../models/accessible-wrapper.model';
+
+@Component({
+  selector: 'ngx-accessible-wrapper-form-body',
+  imports: [NgxVestForms, FormErrorControlDirective],
+  templateUrl: './accessible-wrapper.form.html',
+  providers: [provideFormContract(accessibleWrapperContract)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AccessibleWrapperFormBody {
+  readonly formValue = input.required<AccessibleWrapperModel>();
+  readonly suite = input.required<NgxVestSuite<AccessibleWrapperModel>>();
+
+  readonly formValueChange = output<AccessibleWrapperModel>();
+  readonly submitted = output();
+  readonly resetRequested = output();
+  readonly clearSearchRequested = output();
+
+  private readonly vestForm =
+    viewChild<FormDirective<AccessibleWrapperModel>>('vestForm');
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+        
+  protected onSubmit(): void {
+    this.submitted.emit();
+  }
+
+  protected onReset(): void {
+    this.resetRequested.emit();
+  }
+
+  protected shouldShowErrors(control: FormErrorControlDirective): boolean {
+    return control['errorDisplay'].shouldShowErrors();
+  }
+
+  protected controlErrors(control: FormErrorControlDirective): string[] {
+    return control['errorDisplay'].errors();
+  }
+
+  resetFormState(value: AccessibleWrapperModel): void {
+    this.vestForm()?.resetForm(value);
+  }
+
+  focusFirstInvalidControl(): void {
+    this.vestForm()?.focusFirstInvalidControl();
+  }
+}

--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.page.html
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.page.html
@@ -1,0 +1,57 @@
+<div class="page-container">
+  <ngx-page-title
+    title="Accessible Custom Wrapper"
+    subtitle="Use directive-based ARIA wiring when the built-in wrapper markup is not the right fit."
+  />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
+  <ngx-form-page-layout>
+    <div layout-aside class="sidebar-card-stack">
+      <ngx-card title="What to inspect">
+        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-200">
+          <li>
+            The first field starts with a static hint in
+            <code>aria-describedby</code> and the directive merges its own error
+            ID when needed.
+          </li>
+          <li>
+            The second wrapper contains an input plus a button, so only the
+            input gets manual validation attributes.
+          </li>
+          <li>
+            The adjacent helper button stays free of <code>aria-invalid</code>
+            and validation descriptions.
+          </li>
+        </ul>
+      </ngx-card>
+
+      <ngx-form-state-card [feedback]="feedback()" />
+    </div>
+
+    <div layout-main>
+      @if (submittedValue(); as submitted) {
+        <ngx-alert-panel tone="success" title="Preferences saved">
+          <p>
+            Saved custom-wrapper preferences for
+            <strong>{{ submitted.preferredName }}</strong>.
+          </p>
+        </ngx-alert-panel>
+      }
+
+      <ngx-card
+        title="Directive-based custom wrappers"
+        subtitle="These fields use ngxErrorControl instead of ngx-control-wrapper so the ARIA behavior is visible in plain markup."
+      >
+        <ngx-accessible-wrapper-form-body
+          [formValue]="formValue()"
+          [suite]="suite"
+          (formValueChange)="formValue.set($event)"
+          (submitted)="onSubmit()"
+          (resetRequested)="reset()"
+          (clearSearchRequested)="clearSearchQuery()"
+        />
+      </ngx-card>
+    </div>
+  </ngx-form-page-layout>
+</div>

--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.page.ts
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.page.ts
@@ -1,0 +1,71 @@
+import {
+  ChangeDetectionStrategy,
+  computed,
+  Component,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {
+  createEmptyFormState,
+} from 'ngx-vest-forms';
+import {
+  AccessibleWrapperModel,
+} from '../../models/accessible-wrapper.model';
+import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
+import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
+import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
+import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { PageTitle } from '../../ui/page-title/page-title.component';
+import { accessibleWrapperContent } from './accessible-wrapper.content';
+import { AccessibleWrapperFormBody } from './accessible-wrapper.form';
+import { accessibleWrapperSuite } from './accessible-wrapper.validations';
+
+@Component({
+  selector: 'ngx-accessible-wrapper-page',
+  imports: [
+    PageTitle,
+    Card,
+    AlertPanel,
+    ExampleCardsComponent,
+    FormPageLayout,
+    FormStateCardComponent,
+    AccessibleWrapperFormBody,
+  ],
+  templateUrl: './accessible-wrapper.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AccessibleWrapperPageComponent {
+  protected readonly exampleContent = accessibleWrapperContent;
+  protected readonly suite = accessibleWrapperSuite;
+  protected readonly formValue = signal<AccessibleWrapperModel>({});
+  protected readonly submittedValue = signal<AccessibleWrapperModel | null>(null);
+
+  private readonly formBody = viewChild(AccessibleWrapperFormBody);
+
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
+
+  protected clearSearchQuery(): void {
+    this.formValue.update((current) => ({
+      ...current,
+      searchQuery: '',
+    }));
+    this.submittedValue.set(null);
+  }
+
+  protected onSubmit(): void {
+    if (!this.feedback()?.formState()?.valid) {
+      this.submittedValue.set(null);
+      this.formBody()?.focusFirstInvalidControl();
+      return;
+    }
+
+    this.submittedValue.set(structuredClone(this.formValue()));
+  }
+
+  protected reset(): void {
+    this.submittedValue.set(null);
+    this.formBody()?.resetFormState({});
+    this.formValue.set({});
+  }
+}

--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.validations.ts
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.validations.ts
@@ -1,0 +1,20 @@
+import type { NgxVestSuite } from 'ngx-vest-forms';
+import { create, enforce, omitWhen, test } from 'vest';
+import { AccessibleWrapperModel } from '../../models/accessible-wrapper.model';
+
+export const accessibleWrapperSuite: NgxVestSuite<AccessibleWrapperModel> =
+  create((model: AccessibleWrapperModel) => {
+    test('preferredName', 'Preferred name is required', () => {
+      enforce(model.preferredName).isNotBlank();
+    });
+
+    omitWhen(!model.preferredName, () => {
+      test('preferredName', 'Preferred name must be at least 3 characters', () => {
+        enforce(model.preferredName).longerThanOrEquals(3);
+      });
+    });
+
+    test('searchQuery', 'Search query is required', () => {
+      enforce(model.searchQuery).isNotBlank();
+    });
+  });

--- a/apps/examples/src/app/pages/async-username-form/README.md
+++ b/apps/examples/src/app/pages/async-username-form/README.md
@@ -1,0 +1,56 @@
+# Async Username Availability
+
+Validates a username against a mock remote endpoint, layering the async
+validation pattern on top of the canonical starter wiring.
+
+## Why this demo exists
+
+Async field validation is where most form libraries get awkward: requests
+race, stale responses overwrite fresh ones, and the UI flickers. This demo
+shows the calm, correct way to do it with ngx-vest-forms — cheap rules
+first, the network last, every stale request cancelled.
+
+## What it shows
+
+- A typed `AsyncUsernameModel` (`NgxDeepPartial`) plus its `asyncUsernameShape`
+  contract supplied through `provideFormContract`.
+- A suite **factory** (`createAsyncUsernameSuite(service)`) so the async
+  service is injected by the component while the suite stays a plain,
+  unit-testable Vest spec.
+- Synchronous rules — required, min length 3, pattern `^[a-z0-9_]+$` — that
+  gate the async availability test via `omitWhen`, so the endpoint is only
+  hit once the username is structurally valid.
+- The async test wrapped in `vest/memo` keyed on `[username]` so it does not
+  re-run when other fields change, and aborted via
+  `takeUntil(fromEvent(signal, 'abort'))` when the username changes mid-flight.
+- Pending state read from `createFormFeedbackSignals` and surfaced inline
+  with an `aria-live="polite"` "Checking availability…" hint, plus a success
+  hint when the field is validated, error-free, and not pending.
+
+## Public API used
+
+`NgxVestForms`, `FormDirective`, `provideFormContract`,
+`createFormFeedbackSignals`, `NgxVestSuite`, `NgxDeepPartial`,
+`NgxDeepRequired`. Vest comes from `vest` and `vest/memo`.
+
+## Key files
+
+| File | Responsibility |
+| --- | --- |
+| `async-username.page.ts` / `.html` | Self-contained page + form |
+| `async-username.validations.ts` | Suite factory (testable in isolation) |
+| `username-availability.service.ts` | HttpClient wrapper → `Observable<boolean>` |
+| `../../models/async-username.model.ts` | Model + contract |
+| `async-username.content.ts` | "What this demonstrates / learn" cards |
+
+## Behavior
+
+While the remote check runs, `pending()` is true: the control wrapper sets
+`aria-busy` and an inline polite hint reads "Checking availability…". When
+the username is valid and the check passes, the hint switches to "That
+username is available." A taken name (`admin`, `root`, `support`, `ada`,
+`luke`, `taken`, `test`) yields "Username is already taken". Editing the
+username aborts any in-flight request and re-runs validation against the new
+value, so the result always reflects the latest input. Submitting while
+invalid keeps the success panel hidden; a valid submit shows it. Reset
+clears both the form and the panel.

--- a/apps/examples/src/app/pages/async-username-form/async-username.content.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.content.ts
@@ -1,0 +1,40 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const asyncUsernameContent = defineExampleContent({
+  demonstrates: {
+    icon: '🌐',
+    title: 'What this demonstrates',
+    points: [
+      'An async Vest test that validates a username against a remote endpoint',
+      'Cheap synchronous rules (required, length, pattern) gating the network call via omitWhen',
+      'vest/memo keying the async test on the username so it only re-runs when the value changes',
+      'Aborting the in-flight request through the Vest-provided AbortSignal when the user keeps typing',
+      'Pending state surfaced calmly inline and kept separate from submission state',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'The async validation pattern',
+        points: [
+          'How omitWhen short-circuits the remote check until the value is structurally valid',
+          'Why memo([username]) prevents redundant requests as other fields change',
+          'How takeUntil(fromEvent(signal, "abort")) cancels a stale request on new input',
+        ],
+      },
+      {
+        title: 'Surfacing async UI state',
+        points: [
+          'Reading pending from createFormFeedbackSignals to show a polite "Checking…" hint',
+          'Deriving a success hint from validated fields plus an empty error list',
+          'Keeping the suite a plain Vest spec — the service is injected via a factory',
+        ],
+      },
+    ],
+    nextStep: {
+      label: 'Next: Custom controls',
+      route: 'custom-controls',
+    },
+  },
+});

--- a/apps/examples/src/app/pages/async-username-form/async-username.form.html
+++ b/apps/examples/src/app/pages/async-username-form/async-username.form.html
@@ -1,0 +1,56 @@
+<form
+  ngxVestForm
+  #vestForm="ngxVestForm"
+  [suite]="suite()"
+  [formValue]="formValue()"
+  (formValueChange)="formValueChange.emit($event)"
+  (ngSubmit)="onSubmit()"
+  class="space-y-6"
+>
+  <ngx-control-wrapper class="form-field">
+    <label for="username" class="label-text">Username</label>
+    <input
+      class="input-field"
+      type="text"
+      id="username"
+      name="username"
+      [ngModel]="formValue().username"
+      placeholder="ada_lovelace"
+      autocomplete="off"
+      autocapitalize="none"
+      spellcheck="false"
+    />
+
+    <p aria-live="polite" class="mt-1 min-h-[1.25rem] text-sm">
+      @if (feedback.pending()) {
+        <span class="text-blue-600 dark:text-blue-400">
+          Checking availability…
+        </span>
+      } @else if (usernameResolved()) {
+        <span class="text-green-600 dark:text-green-400">
+          That username is available.
+        </span>
+      }
+    </p>
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label for="displayName" class="label-text">Display name</label>
+    <input
+      class="input-field"
+      type="text"
+      id="displayName"
+      name="displayName"
+      [ngModel]="formValue().displayName"
+      placeholder="Ada Lovelace"
+      autocomplete="name"
+    />
+  </ngx-control-wrapper>
+
+  <div class="flex justify-end gap-3 pt-2">
+    <button type="button" class="btn btn-secondary" (click)="onReset()">
+      Reset
+    </button>
+    <button type="submit" class="btn btn-primary">Reserve username</button>
+  </div>
+</form>

--- a/apps/examples/src/app/pages/async-username-form/async-username.form.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.form.ts
@@ -1,0 +1,70 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxVestForms,
+  NgxVestSuite,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  AsyncUsernameModel,
+  asyncUsernameShape,
+} from '../../models/async-username.model';
+
+@Component({
+  selector: 'ngx-async-username-form-body',
+  imports: [NgxVestForms],
+  templateUrl: './async-username.form.html',
+  providers: [provideFormContract(asyncUsernameShape)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AsyncUsernameFormBody {
+  readonly formValue = input.required<AsyncUsernameModel>();
+  readonly suite = input.required<NgxVestSuite<AsyncUsernameModel>>();
+
+  readonly formValueChange = output<AsyncUsernameModel>();
+  readonly submitted = output();
+  readonly resetRequested = output();
+
+  private readonly vestForm =
+    viewChild<FormDirective<AsyncUsernameModel>>('vestForm');
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+        
+  private readonly usernameErrors = computed(
+    () => this.feedback.formState()?.errors['username'] ?? []
+  );
+
+  protected readonly usernameResolved = computed(() => {
+    const validated = this.feedback.validatedFields() ?? [];
+    return (
+      !this.feedback.pending() &&
+      validated.includes('username') &&
+      this.usernameErrors().length === 0 &&
+      !!this.formValue().username
+    );
+  });
+
+  protected onSubmit(): void {
+    this.submitted.emit();
+  }
+
+  protected onReset(): void {
+    this.resetRequested.emit();
+  }
+
+  resetFormState(value: AsyncUsernameModel): void {
+    this.vestForm()?.resetForm(value);
+  }
+
+  focusFirstInvalidControl(): void {
+    this.vestForm()?.focusFirstInvalidControl();
+  }
+}

--- a/apps/examples/src/app/pages/async-username-form/async-username.page.html
+++ b/apps/examples/src/app/pages/async-username-form/async-username.page.html
@@ -20,12 +20,7 @@
         </ul>
       </ngx-card>
 
-      <ngx-form-state-card
-        [formState]="formState()"
-        [warnings]="warnings()"
-        [validatedFields]="validatedFields()"
-        [pending]="pending()"
-      />
+      <ngx-form-state-card [feedback]="feedback()" />
     </div>
 
     <div layout-main>
@@ -42,71 +37,13 @@
         title="Choose a username"
         subtitle="Try “ada”, “admin”, or “taken” to see the availability check fail."
       >
-        <form
-          ngxVestForm
-          #vestForm="ngxVestForm"
-          [suite]="suite"
+        <ngx-async-username-form-body
           [formValue]="formValue()"
+          [suite]="suite"
           (formValueChange)="formValue.set($event)"
-          (ngSubmit)="onSubmit()"
-          class="space-y-6"
-        >
-          <ngx-control-wrapper class="form-field">
-            <label>
-              <span class="label-text">Username</span>
-              <input
-                class="input-field"
-                type="text"
-                id="username"
-                name="username"
-                [ngModel]="formValue().username"
-                placeholder="ada_lovelace"
-                autocomplete="off"
-                autocapitalize="none"
-                spellcheck="false"
-              />
-            </label>
-
-            <p
-              aria-live="polite"
-              class="mt-1 min-h-[1.25rem] text-sm"
-            >
-              @if (pending()) {
-                <span class="text-blue-600 dark:text-blue-400">
-                  Checking availability…
-                </span>
-              } @else if (usernameResolved()) {
-                <span class="text-green-600 dark:text-green-400">
-                  That username is available.
-                </span>
-              }
-            </p>
-          </ngx-control-wrapper>
-
-          <ngx-control-wrapper class="form-field">
-            <label>
-              <span class="label-text">Display name</span>
-              <input
-                class="input-field"
-                type="text"
-                id="displayName"
-                name="displayName"
-                [ngModel]="formValue().displayName"
-                placeholder="Ada Lovelace"
-                autocomplete="name"
-              />
-            </label>
-          </ngx-control-wrapper>
-
-          <div class="flex justify-end gap-3 pt-2">
-            <button type="button" class="btn btn-secondary" (click)="reset()">
-              Reset
-            </button>
-            <button type="submit" class="btn btn-primary">
-              Reserve username
-            </button>
-          </div>
-        </form>
+          (submitted)="onSubmit()"
+          (resetRequested)="reset()"
+        />
       </ngx-card>
     </div>
   </ngx-form-page-layout>

--- a/apps/examples/src/app/pages/async-username-form/async-username.page.html
+++ b/apps/examples/src/app/pages/async-username-form/async-username.page.html
@@ -1,0 +1,113 @@
+<div class="page-container">
+  <ngx-page-title
+    title="Async Username Availability"
+    subtitle="Validate a username against a mock remote endpoint with calm pending, success, and failure states."
+  />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
+  <ngx-form-page-layout>
+    <div layout-aside class="sidebar-card-stack">
+      <ngx-card title="How async validation behaves">
+        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-200">
+          <li>Cheap rules run first — the network is only hit when valid.</li>
+          <li>
+            Typing again aborts the in-flight request via an
+            <code>AbortSignal</code>.
+          </li>
+          <li><code>memo</code> avoids re-running the check needlessly.</li>
+          <li>Pending state is separate from submission state.</li>
+        </ul>
+      </ngx-card>
+
+      <ngx-form-state-card
+        [formState]="formState()"
+        [warnings]="warnings()"
+        [validatedFields]="validatedFields()"
+        [pending]="pending()"
+      />
+    </div>
+
+    <div layout-main>
+      @if (submittedValue(); as submitted) {
+        <ngx-alert-panel tone="success" title="Username reserved">
+          <p>
+            Nice — <strong>{{ submitted.username }}</strong> is available and
+            reserved for {{ submitted.displayName }}.
+          </p>
+        </ngx-alert-panel>
+      }
+
+      <ngx-card
+        title="Choose a username"
+        subtitle="Try “ada”, “admin”, or “taken” to see the availability check fail."
+      >
+        <form
+          ngxVestForm
+          #vestForm="ngxVestForm"
+          [suite]="suite"
+          [formValue]="formValue()"
+          (formValueChange)="formValue.set($event)"
+          (ngSubmit)="onSubmit()"
+          class="space-y-6"
+        >
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Username</span>
+              <input
+                class="input-field"
+                type="text"
+                id="username"
+                name="username"
+                [ngModel]="formValue().username"
+                placeholder="ada_lovelace"
+                autocomplete="off"
+                autocapitalize="none"
+                spellcheck="false"
+              />
+            </label>
+
+            <p
+              aria-live="polite"
+              class="mt-1 min-h-[1.25rem] text-sm"
+            >
+              @if (pending()) {
+                <span class="text-blue-600 dark:text-blue-400">
+                  Checking availability…
+                </span>
+              } @else if (usernameResolved()) {
+                <span class="text-green-600 dark:text-green-400">
+                  That username is available.
+                </span>
+              }
+            </p>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Display name</span>
+              <input
+                class="input-field"
+                type="text"
+                id="displayName"
+                name="displayName"
+                [ngModel]="formValue().displayName"
+                placeholder="Ada Lovelace"
+                autocomplete="name"
+              />
+            </label>
+          </ngx-control-wrapper>
+
+          <div class="flex justify-end gap-3 pt-2">
+            <button type="button" class="btn btn-secondary" (click)="reset()">
+              Reset
+            </button>
+            <button type="submit" class="btn btn-primary">
+              Reserve username
+            </button>
+          </div>
+        </form>
+      </ngx-card>
+    </div>
+  </ngx-form-page-layout>
+</div>

--- a/apps/examples/src/app/pages/async-username-form/async-username.page.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.page.ts
@@ -1,0 +1,108 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxVestForms,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  AsyncUsernameModel,
+  asyncUsernameShape,
+} from '../../models/async-username.model';
+import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
+import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
+import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
+import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { PageTitle } from '../../ui/page-title/page-title.component';
+import { asyncUsernameContent } from './async-username.content';
+import { createAsyncUsernameSuite } from './async-username.validations';
+import { UsernameAvailabilityService } from './username-availability.service';
+
+/**
+ * Async Username Availability — a self-contained demo that validates a
+ * username against a mock remote endpoint.
+ *
+ * It mirrors the canonical starter wiring (one `ngxVestForm`, a form
+ * contract, packaged feedback signals) and layers the async validation
+ * pattern from the purchase demo on top: cheap synchronous rules gate an
+ * `omitWhen`-wrapped, `memo`-keyed async test that aborts in-flight requests
+ * when the username changes. Pending and submission state are kept separate
+ * so the UI stays calm while the network call is in flight.
+ */
+@Component({
+  selector: 'ngx-async-username-page',
+  imports: [
+    NgxVestForms,
+    PageTitle,
+    Card,
+    AlertPanel,
+    FormPageLayout,
+    FormStateCardComponent,
+    ExampleCardsComponent,
+  ],
+  templateUrl: './async-username.page.html',
+  providers: [provideFormContract(asyncUsernameShape)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AsyncUsernamePageComponent {
+  protected readonly exampleContent = asyncUsernameContent;
+
+  /** Suite is built in the component so the async service can be injected. */
+  protected readonly suite = createAsyncUsernameSuite(
+    inject(UsernameAvailabilityService)
+  );
+
+  /** The form value is the single source of truth, owned by the page. */
+  protected readonly formValue = signal<AsyncUsernameModel>({});
+  protected readonly submittedValue = signal<AsyncUsernameModel | null>(null);
+
+  private readonly vestForm =
+    viewChild<FormDirective<AsyncUsernameModel>>('vestForm');
+  private readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+  protected readonly formState = this.feedback.formState;
+  protected readonly warnings = this.feedback.warnings;
+  protected readonly validatedFields = this.feedback.validatedFields;
+  protected readonly pending = this.feedback.pending;
+
+  /** Errors currently attached to the username field. */
+  private readonly usernameErrors = computed(
+    () => this.formState()?.errors['username'] ?? []
+  );
+
+  /**
+   * Show the calm success hint only once the username has been validated,
+   * has no errors, and no async check is in flight.
+   */
+  protected readonly usernameResolved = computed(() => {
+    const validated = this.validatedFields() ?? [];
+    return (
+      !this.pending() &&
+      validated.includes('username') &&
+      this.usernameErrors().length === 0 &&
+      !!this.formValue().username
+    );
+  });
+
+  protected onSubmit(): void {
+    if (!this.formState()?.valid) {
+      this.submittedValue.set(null);
+      return;
+    }
+    this.submittedValue.set(structuredClone(this.formValue()));
+  }
+
+  protected reset(): void {
+    this.submittedValue.set(null);
+    this.vestForm()?.resetForm({});
+    this.formValue.set({});
+  }
+}

--- a/apps/examples/src/app/pages/async-username-form/async-username.page.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.page.ts
@@ -7,14 +7,10 @@ import {
   viewChild,
 } from '@angular/core';
 import {
-  createFormFeedbackSignals,
-  FormDirective,
-  NgxVestForms,
-  provideFormContract,
+  createEmptyFormState,
 } from 'ngx-vest-forms';
 import {
   AsyncUsernameModel,
-  asyncUsernameShape,
 } from '../../models/async-username.model';
 import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
 import { Card } from '../../ui/card/card.component';
@@ -23,6 +19,7 @@ import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.compo
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
 import { asyncUsernameContent } from './async-username.content';
+import { AsyncUsernameFormBody } from './async-username.form';
 import { createAsyncUsernameSuite } from './async-username.validations';
 import { UsernameAvailabilityService } from './username-availability.service';
 
@@ -30,8 +27,8 @@ import { UsernameAvailabilityService } from './username-availability.service';
  * Async Username Availability — a self-contained demo that validates a
  * username against a mock remote endpoint.
  *
- * It mirrors the canonical starter wiring (one `ngxVestForm`, a form
- * contract, packaged feedback signals) and layers the async validation
+ * It mirrors the canonical starter wiring (page-owned state + focused form
+ * markup in `async-username.form.html`) and layers the async validation
  * pattern from the purchase demo on top: cheap synchronous rules gate an
  * `omitWhen`-wrapped, `memo`-keyed async test that aborts in-flight requests
  * when the username changes. Pending and submission state are kept separate
@@ -40,16 +37,15 @@ import { UsernameAvailabilityService } from './username-availability.service';
 @Component({
   selector: 'ngx-async-username-page',
   imports: [
-    NgxVestForms,
     PageTitle,
     Card,
     AlertPanel,
     FormPageLayout,
     FormStateCardComponent,
     ExampleCardsComponent,
+    AsyncUsernameFormBody,
   ],
   templateUrl: './async-username.page.html',
-  providers: [provideFormContract(asyncUsernameShape)],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AsyncUsernamePageComponent {
@@ -64,37 +60,14 @@ export class AsyncUsernamePageComponent {
   protected readonly formValue = signal<AsyncUsernameModel>({});
   protected readonly submittedValue = signal<AsyncUsernameModel | null>(null);
 
-  private readonly vestForm =
-    viewChild<FormDirective<AsyncUsernameModel>>('vestForm');
-  private readonly feedback = createFormFeedbackSignals(this.vestForm);
+  private readonly formBody = viewChild(AsyncUsernameFormBody);
 
-  protected readonly formState = this.feedback.formState;
-  protected readonly warnings = this.feedback.warnings;
-  protected readonly validatedFields = this.feedback.validatedFields;
-  protected readonly pending = this.feedback.pending;
-
-  /** Errors currently attached to the username field. */
-  private readonly usernameErrors = computed(
-    () => this.formState()?.errors['username'] ?? []
-  );
-
-  /**
-   * Show the calm success hint only once the username has been validated,
-   * has no errors, and no async check is in flight.
-   */
-  protected readonly usernameResolved = computed(() => {
-    const validated = this.validatedFields() ?? [];
-    return (
-      !this.pending() &&
-      validated.includes('username') &&
-      this.usernameErrors().length === 0 &&
-      !!this.formValue().username
-    );
-  });
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
 
   protected onSubmit(): void {
-    if (!this.formState()?.valid) {
+    if (!this.feedback()?.formState()?.valid) {
       this.submittedValue.set(null);
+      this.formBody()?.focusFirstInvalidControl();
       return;
     }
     this.submittedValue.set(structuredClone(this.formValue()));
@@ -102,7 +75,7 @@ export class AsyncUsernamePageComponent {
 
   protected reset(): void {
     this.submittedValue.set(null);
-    this.vestForm()?.resetForm({});
+    this.formBody()?.resetFormState({});
     this.formValue.set({});
   }
 }

--- a/apps/examples/src/app/pages/async-username-form/async-username.validations.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.validations.ts
@@ -27,20 +27,22 @@ export const createAsyncUsernameSuite = (
 ): NgxVestSuite<AsyncUsernameModel> => {
   const suite: NgxVestSuite<AsyncUsernameModel> = create(
     (model: AsyncUsernameModel) => {
+      const username = model.username ?? '';
+
       test('username', 'Username is required', () => {
         enforce(model.username).isNotBlank();
       });
 
-      omitWhen(!model.username, () => {
+      omitWhen(!username, () => {
         test('username', 'Username must be at least 3 characters', () => {
-          enforce(model.username).longerThanOrEquals(3);
+          enforce(username).longerThanOrEquals(3);
         });
 
         test(
           'username',
           'Use only lowercase letters, digits, and underscores',
           () => {
-            enforce(model.username ?? '').matches(USERNAME_PATTERN);
+            enforce(username).matches(USERNAME_PATTERN);
           }
         );
       });
@@ -49,9 +51,7 @@ export const createAsyncUsernameSuite = (
       // synchronous rules above. `omitWhen` short-circuits the async test
       // while the value is blank / too short / malformed.
       omitWhen(
-        !model.username ||
-          (model.username as string).length < 3 ||
-          !USERNAME_PATTERN.test(model.username as string),
+        !username || username.length < 3 || !USERNAME_PATTERN.test(username),
         () => {
           memo(
             () => {
@@ -61,7 +61,7 @@ export const createAsyncUsernameSuite = (
                 async ({ signal }) => {
                   const taken = await lastValueFrom(
                     service
-                      .isUsernameTaken(model.username as string)
+                      .isUsernameTaken(username)
                       .pipe(takeUntil(fromEvent(signal, 'abort')))
                   );
 
@@ -71,7 +71,7 @@ export const createAsyncUsernameSuite = (
                 }
               );
             },
-            [model.username]
+            [username]
           );
         }
       );

--- a/apps/examples/src/app/pages/async-username-form/async-username.validations.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.validations.ts
@@ -1,0 +1,86 @@
+import { type NgxVestSuite } from 'ngx-vest-forms';
+import { fromEvent, lastValueFrom, takeUntil } from 'rxjs';
+import { create, enforce, omitWhen, test } from 'vest';
+import { memo } from 'vest/memo';
+import { AsyncUsernameModel } from '../../models/async-username.model';
+import { UsernameAvailabilityService } from './username-availability.service';
+
+type AvailabilityCheck = Pick<UsernameAvailabilityService, 'isUsernameTaken'>;
+
+const USERNAME_PATTERN = /^[a-z0-9_]+$/;
+
+/**
+ * Factory that builds the Async Username Availability suite around an
+ * availability service. Mirrors `createPurchaseValidationSuite`: the suite is
+ * a plain Vest spec with no Angular dependency, so it can be unit-tested by
+ * calling `createAsyncUsernameSuite(fakeService)(model, field)` directly.
+ *
+ * Synchronous rules (required / length / pattern) run first and gate the
+ * async availability check via `omitWhen`, so the network is only hit once
+ * the username is structurally valid. The async test is wrapped in `memo`
+ * keyed on the username so it does not re-run while other fields change, and
+ * it aborts the in-flight request when the username changes by listening to
+ * the Vest-provided `signal`'s `abort` event.
+ */
+export const createAsyncUsernameSuite = (
+  service: AvailabilityCheck
+): NgxVestSuite<AsyncUsernameModel> => {
+  const suite: NgxVestSuite<AsyncUsernameModel> = create(
+    (model: AsyncUsernameModel) => {
+      test('username', 'Username is required', () => {
+        enforce(model.username).isNotBlank();
+      });
+
+      omitWhen(!model.username, () => {
+        test('username', 'Username must be at least 3 characters', () => {
+          enforce(model.username).longerThanOrEquals(3);
+        });
+
+        test(
+          'username',
+          'Use only lowercase letters, digits, and underscores',
+          () => {
+            enforce(model.username ?? '').matches(USERNAME_PATTERN);
+          }
+        );
+      });
+
+      // Only contact the remote endpoint once the username passes the cheap
+      // synchronous rules above. `omitWhen` short-circuits the async test
+      // while the value is blank / too short / malformed.
+      omitWhen(
+        !model.username ||
+          (model.username as string).length < 3 ||
+          !USERNAME_PATTERN.test(model.username as string),
+        () => {
+          memo(
+            () => {
+              test(
+                'username',
+                'Username is already taken',
+                async ({ signal }) => {
+                  const taken = await lastValueFrom(
+                    service
+                      .isUsernameTaken(model.username as string)
+                      .pipe(takeUntil(fromEvent(signal, 'abort')))
+                  );
+
+                  if (taken) {
+                    return Promise.reject();
+                  }
+                }
+              );
+            },
+            [model.username]
+          );
+        }
+      );
+
+      test('displayName', 'Display name is required', () => {
+        enforce(model.displayName).isNotBlank();
+      });
+    }
+  );
+
+  return suite;
+};

--- a/apps/examples/src/app/pages/async-username-form/username-availability.service.ts
+++ b/apps/examples/src/app/pages/async-username-form/username-availability.service.ts
@@ -1,0 +1,26 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { map, Observable } from 'rxjs';
+
+/**
+ * Talks to the in-app mock endpoint `GET /api/username-availability/:name`.
+ *
+ * The interceptor responds with `{ username, available }`. We map a response
+ * of `available === false` to "taken" so the validation suite can simply
+ * reject when the username is unavailable. Mirrors `SwapiService` — an
+ * injectable HttpClient wrapper returning an `Observable<boolean>`.
+ */
+@Injectable({ providedIn: 'root' })
+export class UsernameAvailabilityService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly baseUrl = '/api/username-availability';
+
+  /** Resolves `true` when the username is already taken. */
+  isUsernameTaken(name: string): Observable<boolean> {
+    return this.httpClient
+      .get<{ username: string; available: boolean }>(
+        `${this.baseUrl}/${encodeURIComponent(name)}`
+      )
+      .pipe(map((res) => res.available === false));
+  }
+}

--- a/apps/examples/src/app/pages/auto-save-demo/README.md
+++ b/apps/examples/src/app/pages/auto-save-demo/README.md
@@ -1,0 +1,65 @@
+# Auto-Save Draft Demo
+
+Persist draft changes on blur while keeping validation and final submission
+separate.
+
+## Why this demo exists
+
+Real applications often want to protect a user's in-progress work without
+forcing the form to be valid first. This demo shows how to build a robust
+blur-driven auto-save on top of `ngx-vest-forms` while keeping draft
+persistence strictly independent of validation and final submit. It also
+demonstrates how to keep that persistence layer resilient under rapid blur
+events and a Reset that races an in-flight save.
+
+## What it does
+
+- Blurring a **changed** field queues a draft save. The save is debounced by
+  identity: a serialized draft key dedupes unchanged blurs and saves that are
+  already queued.
+- Draft saves run through an RxJS `Subject` + `concatMap` pipeline so writes
+  stay ordered even during a burst of blur events.
+- Drafts persist to `sessionStorage` (`AutoSaveDemoService`). A draft is
+  restored on page load and its status surfaced in the sidebar.
+- A `#saveGeneration` counter is bumped on Reset. Any queued or in-flight save
+  carrying an older generation is dropped before it can rewrite the cleared
+  draft.
+- Validation runs independently of persistence: a draft can be saved while the
+  form is still invalid. The explicit "Save" button, by contrast, requires a
+  valid form.
+- Project name `fail` triggers a simulated save failure to exercise the retry
+  path.
+
+## ngx-vest-forms APIs showcased
+
+- `NgxVestForms` directive bundle on the form body.
+- `NgxFieldBlurEvent<T>` — the `(fieldBlurred)` payload exposing `field`,
+  `formValue`, and `dirty` used to drive blur-based saving.
+- `createValidationConfig<T>()` with `.bidirectional('quantity',
+  'quantityJustification')` and `.whenChanged('preferredContactMethod',
+  'email')` for coordinated dependent validation.
+- `FormDirective` view-child state: `formState()`, `fieldWarnings()`,
+  `touchedFieldPaths()`, plus `resetForm()`.
+- Vest `warn()` for non-blocking `notes` guidance.
+- `fieldWarningsToRecord` / `createEmptyFormState` helpers for presentational
+  state.
+
+## Key files
+
+- `auto-save-demo.page.ts` — orchestration: blur handling, save queue,
+  generation counter, reset, restored-draft status.
+- `auto-save-demo.form.ts` / `.form.html` — the form body and exposed state.
+- `auto-save-demo.validations.ts` — Vest suite (dependent pair, conditional
+  email, notes warning).
+- `auto-save-demo.service.ts` — `sessionStorage`-backed draft store with
+  simulated latency and failure.
+- `auto-save-demo.content.ts` — in-app "What this demonstrates / learn" cards.
+
+## Behavior notes
+
+- Saving a draft never implies the form is valid; the two concerns are kept
+  separate by design.
+- Untouched dependent fields stay visually quiet until their own blur even
+  though the underlying rule may already require them.
+- Resetting clears the stored draft and guarantees no stale queued save can
+  resurrect it.

--- a/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.content.ts
+++ b/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.content.ts
@@ -1,0 +1,48 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const autoSaveContent = defineExampleContent({
+  demonstrates: {
+    icon: '💾',
+    title: 'What this demonstrates',
+    points: [
+      'Drafts auto-save when a changed field blurs, driven by the (fieldBlurred) NgxFieldBlurEvent payload (field, formValue, dirty).',
+      'Draft persistence is decoupled from final validation: a draft can save even while the form is invalid.',
+      'A serialized draft key dedupes saves so an unchanged blur or an already-queued draft is not re-sent.',
+      'A generation counter dropped stale in-flight saves on Reset so a clear cannot be overwritten by a queued save.',
+      'Dependent-pair validation: quantity ↔ quantityJustification are bidirectionally required, while untouched dependents stay visually quiet until their own blur.',
+      'Conditional validation: email is only required when preferredContactMethod is "email".',
+      'Non-blocking warnings: a short notes value warns without blocking the draft save.',
+      'Restore-on-load: a previous draft is rehydrated from sessionStorage; project name "fail" simulates a save failure with retry.',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Blur-driven persistence',
+        points: [
+          'Use NgxFieldBlurEvent to react to per-field blur with the current value and dirty flag.',
+          'Separate "save a draft" from "submit a valid form" so persistence never implies validity.',
+          'Queue and serialize saves with concatMap so blur storms collapse into ordered writes.',
+        ],
+      },
+      {
+        title: 'Coordinated validation',
+        points: [
+          'Wire bidirectional and whenChanged dependencies with createValidationConfig.',
+          'Keep dependent errors calm: only revalidate the partner field, not the whole form.',
+          'Model warnings with Vest warn() so they inform without blocking save or submit.',
+        ],
+      },
+      {
+        title: 'Resilient draft lifecycle',
+        points: [
+          'Use a generation counter to discard saves queued before a Reset.',
+          'Dedupe writes with a stable serialized draft key.',
+          'Rehydrate and surface restored drafts from sessionStorage on load.',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Multi-form wizard', route: 'wizard' },
+  },
+});

--- a/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.form.html
+++ b/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.form.html
@@ -54,7 +54,7 @@
 
       @if (formValue().preferredContactMethod === 'email') {
       <div class="mt-6">
-        <ngx-control-wrapper [errorDisplayMode]="'on-blur'" class="form-field">
+        <ngx-control-wrapper errorDisplayMode="on-blur" class="form-field">
           <label for="email">
             <span class="label-text">Notification email</span>
             <input
@@ -77,7 +77,7 @@
       description="Either field can make the other required immediately, while the dependent error still waits for that field's own blur."
     >
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
-        <ngx-control-wrapper [errorDisplayMode]="'on-blur'" class="form-field">
+        <ngx-control-wrapper errorDisplayMode="on-blur" class="form-field">
           <label for="quantity">
             <span class="label-text">Quantity</span>
             <input
@@ -91,7 +91,7 @@
           </label>
         </ngx-control-wrapper>
 
-        <ngx-control-wrapper [errorDisplayMode]="'on-blur'" class="form-field">
+        <ngx-control-wrapper errorDisplayMode="on-blur" class="form-field">
           <label for="quantityJustification">
             <span class="label-text">Quantity justification</span>
             <textarea
@@ -112,7 +112,7 @@
       title="Notes"
       description="Warnings are non-blocking, so they can guide better drafts without blocking auto-save."
     >
-      <ngx-control-wrapper [warningDisplayMode]="'on-dirty'" class="form-field">
+      <ngx-control-wrapper warningDisplayMode="on-dirty" class="form-field">
         <label for="notes">
           <span class="label-text">Draft notes</span>
           <textarea

--- a/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.form.ts
+++ b/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.form.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import {
   createEmptyFormState,
+  createFormFeedbackSignals,
   fieldWarningsToRecord,
   FormDirective,
   NgxFieldBlurEvent,
@@ -39,23 +40,7 @@ export class AutoSaveDemoFormBody {
   private readonly vestForm =
     viewChild<FormDirective<AutoSaveDemoModel>>('vestForm');
 
-  readonly formState = computed(() => {
-    const state = this.vestForm()?.formState();
-    if (!state) return createEmptyFormState<AutoSaveDemoModel>();
-    return state;
-  });
-
-  readonly warnings = computed(() =>
-    fieldWarningsToRecord(this.vestForm()?.fieldWarnings() ?? new Map())
-  );
-
-  readonly validatedFields = computed(
-    () => this.vestForm()?.touchedFieldPaths() ?? []
-  );
-
-  readonly pending = computed(
-    () => this.vestForm()?.ngForm.form.pending ?? false
-  );
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
 
   protected onSubmit(): void {
     this.submitted.emit();

--- a/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.page.html
+++ b/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.page.html
@@ -1,8 +1,10 @@
 <div class="page-container">
   <ngx-page-title
     title="Auto-Save Draft Demo"
-    subtitle="Persist drafts on blur without conflating draft persistence and final validation."
+    subtitle="Persist draft changes on blur while keeping validation and final submission separate."
   />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
 
   <ngx-form-page-layout>
     <div layout-aside class="sidebar-card-stack">

--- a/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.page.html
+++ b/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.page.html
@@ -45,14 +45,11 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="formBody.formState()"
-        [warnings]="formBody.warnings()"
+        [feedback]="feedback()"
         [info]="formInfo()"
         [validationErrorRules]="validationErrorRules"
         [validationWarningRules]="validationWarningRules"
-        [validatedFields]="formBody.validatedFields()"
-        [pending]="formBody.pending()"
-      />
+        />
     </div>
 
     <div layout-main>

--- a/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.page.ts
+++ b/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.page.ts
@@ -71,6 +71,7 @@ type AutoSaveRequest = {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AutoSaveDemoPageComponent {
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
   private readonly autoSaveService = inject(AutoSaveDemoService);
   private readonly formBody = viewChild(AutoSaveDemoFormBody);
   private readonly autoSaveRequests = new Subject<AutoSaveRequest>();
@@ -247,7 +248,7 @@ export class AutoSaveDemoPageComponent {
   }
 
   protected save(): void {
-    if (!this.formBody()?.formState().valid) {
+    if (!this.feedback()?.formState().valid) {
       return;
     }
 

--- a/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.page.ts
+++ b/apps/examples/src/app/pages/auto-save-demo/auto-save-demo.page.ts
@@ -23,9 +23,11 @@ import {
 } from '../../models/auto-save-demo.model';
 import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
 import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
+import { autoSaveContent } from './auto-save-demo.content';
 import { AutoSaveDemoFormBody } from './auto-save-demo.form';
 import {
   AutoSaveDemoService,
@@ -58,6 +60,7 @@ type AutoSaveRequest = {
   imports: [
     AlertPanel,
     Card,
+    ExampleCardsComponent,
     FormPageLayout,
     FormStateCardComponent,
     PageTitle,
@@ -80,6 +83,7 @@ export class AutoSaveDemoPageComponent {
   protected readonly formValue = signal<AutoSaveDemoModel>(
     this.restoredDraft?.draft ?? initialAutoSaveDemoValue
   );
+  protected readonly exampleContent = autoSaveContent;
   protected readonly suite = autoSaveDemoSuite;
   protected readonly validationConfig =
     createValidationConfig<AutoSaveDemoModel>()

--- a/apps/examples/src/app/pages/business-hours-form/README.md
+++ b/apps/examples/src/app/pages/business-hours-form/README.md
@@ -1,0 +1,55 @@
+# Business Hours Form
+
+Validation for a dynamic collection of time ranges, where the rules span both
+individual entries and the collection as a whole.
+
+## Why it exists
+
+Form arrays are where validation usually breaks: entries appear and disappear,
+cross-field rules need to re-run, and form-level invariants (like "no overlap")
+depend on every entry at once. This demo is the canonical answer to "how do I
+validate a list whose shape changes at runtime".
+
+## What it does
+
+- Renders a keyed map of business hours, each with a `from` and `to` time, plus
+  an "add new" row.
+- Validates **every entry** by iterating the record with Vest `each()` and
+  emitting tests under `businessHours.values.<key>.*`.
+- Applies a **per-entry cross-field rule**: `to` must be later than `from`.
+- Applies two **ROOT_FORM rules**: at least one entry must exist, and no two
+  ranges may overlap.
+- Keeps the **add-new row** non-blocking while both inputs are empty
+  (`allowEmptyPair`), and validates it as a pair once the user starts typing.
+- After a structural add/remove, the page calls `triggerFormValidation()` so
+  the ROOT_FORM and conditional rules re-evaluate against the new structure.
+
+## ngx-vest-forms APIs showcased
+
+- `NgxVestForms`, `FormDirective`, `provideFormContract`
+- `createValidationConfig().bidirectional()` pairing the add-new `from`/`to`
+- `FormDirective.triggerFormValidation()` for manual revalidation after
+  structural changes
+- `createFormFeedbackSignals()` for `formState`, `warnings`,
+  `validatedFields`, `pending`
+- `ROOT_FORM` token for form-level errors
+- `NgxVestSuite` / Vest `create`, `each`, `test`, `enforce`, `omitWhen`
+
+## Key files
+
+- `business-hours.page.ts` / `.html` — page shell, validationConfig, and the
+  structural-change handler that triggers revalidation
+- `business-hours.form.ts` / `.html` — the form body component
+- `business-hours.validations.ts` — the suite, time parsing, and overlap logic
+- `ui/business-hours/business-hours.component.ts` — the add/remove UI
+- `../../models/business-hours-form.model.ts` — model, contract, initial value
+
+## Behaviour notes
+
+- `omitWhen` controls *whether* a test runs; `validationConfig` controls *when*
+  Angular asks for revalidation. The add-new pair needs both, which is why the
+  suite documents the `bidirectional()` requirement inline.
+- Time format accepts `HH:MM` or a 4-digit `HHMM` string; invalid times skip the
+  cross-field comparison so users see a format error first.
+- Adding/removing an entry clears the add-new slot to keep the UI ready for the
+  next entry.

--- a/apps/examples/src/app/pages/business-hours-form/business-hours.content.ts
+++ b/apps/examples/src/app/pages/business-hours-form/business-hours.content.ts
@@ -1,0 +1,46 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const businessHoursContent = defineExampleContent({
+  demonstrates: {
+    icon: '🕒',
+    title: 'What this demonstrates',
+    points: [
+      'A dynamic, keyed collection of from/to time ranges that can be added and removed at runtime',
+      'Per-entry field validation generated with Vest each() over the collection entries',
+      'Cross-field rule per entry: the "to" time must be later than the "from" time',
+      'Two ROOT_FORM rules: at least one entry is required, and no two ranges may overlap',
+      'An "add new" slot that stays valid while both inputs are empty (allowEmptyPair) and validates as a pair once typing starts',
+      'createValidationConfig().bidirectional() pairing the add-new from/to so editing one re-runs the other',
+      'Manual revalidation via triggerFormValidation() after structural add/remove changes',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Dynamic collections',
+        points: [
+          'Iterate a keyed record with Vest each() to validate every entry under its own path',
+          'Keep an "add new" row optional with omitWhen + an allowEmptyPair guard',
+          'Re-trigger the suite after structural changes so ROOT_FORM rules re-evaluate',
+        ],
+      },
+      {
+        title: 'omitWhen + validationConfig together',
+        points: [
+          'omitWhen decides WHETHER a cross-field test runs; validationConfig decides WHEN to revalidate',
+          'A bidirectional pair is required so editing "from" re-runs the "to" check and vice versa',
+          'Format checks are themselves gated with omitWhen so blank fields stay quiet',
+        ],
+      },
+      {
+        title: 'Form-level rules',
+        points: [
+          'Express "at least one" and "no overlap" as ROOT_FORM tests',
+          'Surface the single ROOT_FORM message separately from per-field errors',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Async validation', route: 'async-username' },
+  },
+});

--- a/apps/examples/src/app/pages/business-hours-form/business-hours.form.ts
+++ b/apps/examples/src/app/pages/business-hours-form/business-hours.form.ts
@@ -45,14 +45,6 @@ export class BusinessHoursFormBody {
     viewChild<FormDirective<BusinessHoursFormModel>>('vestForm');
   readonly feedback = createFormFeedbackSignals(this.vestForm);
 
-  /** Exposes the directive's packaged form state with up-to-date errors. */
-  
-  /** Exposes field warnings as a plain Record for presentational components. */
-  
-  /** Field paths that have been validated (touched/blurred or submitted). */
-  
-  /** True while async validation is in progress. */
-  
   protected onBusinessHoursChange(values: BusinessHoursMap): void {
     this.businessHoursChange.emit(values);
   }

--- a/apps/examples/src/app/pages/business-hours-form/business-hours.form.ts
+++ b/apps/examples/src/app/pages/business-hours-form/business-hours.form.ts
@@ -43,20 +43,16 @@ export class BusinessHoursFormBody {
 
   private readonly vestForm =
     viewChild<FormDirective<BusinessHoursFormModel>>('vestForm');
-  private readonly formFeedback = createFormFeedbackSignals(this.vestForm);
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
 
   /** Exposes the directive's packaged form state with up-to-date errors. */
-  readonly formState = this.formFeedback.formState;
-
+  
   /** Exposes field warnings as a plain Record for presentational components. */
-  readonly warnings = this.formFeedback.warnings;
-
+  
   /** Field paths that have been validated (touched/blurred or submitted). */
-  readonly validatedFields = this.formFeedback.validatedFields;
-
+  
   /** True while async validation is in progress. */
-  readonly pending = this.formFeedback.pending;
-
+  
   protected onBusinessHoursChange(values: BusinessHoursMap): void {
     this.businessHoursChange.emit(values);
   }

--- a/apps/examples/src/app/pages/business-hours-form/business-hours.page.html
+++ b/apps/examples/src/app/pages/business-hours-form/business-hours.page.html
@@ -30,11 +30,8 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="formBody.formState()"
-        [warnings]="formBody.warnings()"
-        [validatedFields]="formBody.validatedFields()"
-        [pending]="formBody.pending()"
-      />
+        [feedback]="formBody.feedback"
+        />
     </div>
 
     <div layout-main>

--- a/apps/examples/src/app/pages/business-hours-form/business-hours.page.html
+++ b/apps/examples/src/app/pages/business-hours-form/business-hours.page.html
@@ -4,6 +4,8 @@
     subtitle="Validate dynamic time ranges with cross-field and form-level rules."
   />
 
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
   <ngx-form-page-layout>
     <div layout-aside class="sidebar-card-stack">
       <ngx-card title="Complex Validations">

--- a/apps/examples/src/app/pages/business-hours-form/business-hours.page.ts
+++ b/apps/examples/src/app/pages/business-hours-form/business-hours.page.ts
@@ -13,7 +13,9 @@ import {
 import { Card } from '../../ui/card/card.component';
 import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
+import { businessHoursContent } from './business-hours.content';
 import { BusinessHoursFormBody } from './business-hours.form';
 import { businessHoursSuite } from './business-hours.validations';
 import { BusinessHoursMap } from './ui/business-hours/business-hours.component';
@@ -26,6 +28,7 @@ import { BusinessHoursMap } from './ui/business-hours/business-hours.component';
     FormStateCardComponent,
     PageTitle,
     BusinessHoursFormBody,
+    ExampleCardsComponent,
   ],
   templateUrl: './business-hours.page.html',
   styleUrls: ['./business-hours.page.scss'],
@@ -34,6 +37,8 @@ import { BusinessHoursMap } from './ui/business-hours/business-hours.component';
 export class BusinessHoursPageComponent {
   /** Reference to form-body for triggering validation after structural changes */
   private readonly formBody = viewChild(BusinessHoursFormBody);
+
+  protected readonly exampleContent = businessHoursContent;
 
   protected readonly formValue = signal<BusinessHoursFormModel>(
     initialBusinessHoursFormValue

--- a/apps/examples/src/app/pages/business-hours-form/business-hours.page.ts
+++ b/apps/examples/src/app/pages/business-hours-form/business-hours.page.ts
@@ -35,6 +35,7 @@ import { BusinessHoursMap } from './ui/business-hours/business-hours.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BusinessHoursPageComponent {
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
   /** Reference to form-body for triggering validation after structural changes */
   private readonly formBody = viewChild(BusinessHoursFormBody);
 
@@ -46,7 +47,7 @@ export class BusinessHoursPageComponent {
   protected readonly businessHoursSuite = businessHoursSuite;
   protected readonly ROOT_FORM = ROOT_FORM;
   protected readonly rootFormError = computed(
-    () => this.formBody()?.formState()?.errors[ROOT_FORM]?.[0]
+    () => this.feedback()?.formState()?.errors[ROOT_FORM]?.[0]
   );
 
   protected readonly validationConfig =

--- a/apps/examples/src/app/pages/business-policy-form/README.md
+++ b/apps/examples/src/app/pages/business-policy-form/README.md
@@ -1,0 +1,72 @@
+# Vest-First Business Policy
+
+A business-account application that models real policy in plain Vest:
+conditional rules, a cross-field constraint, and advisory guidance that is kept
+deliberately separate from blocking errors.
+
+## Why it exists
+
+Business forms are mostly *policy*, not field presence. The interesting rules
+are conditional ("VAT ID only for EU businesses"), cross-field ("credit limit
+must fit the revenue band"), and advisory ("this looks high — expect manual
+review"). Advisory guidance should never block a submit. Vest expresses all of
+this naturally with `omitWhen`, `ROOT_FORM`, and `warn()`, and the suite stays a
+plain, unit-testable spec with no Angular dependency.
+
+## The policy
+
+### Errors — these block submission
+
+- `accountType` is required
+- `legalName` is required
+- `country` is required
+- `vatId` is required **only** when `accountType === 'business'` **and**
+  `country` is in the EU set (conditional via `omitWhen`)
+- `requestedCreditLimit` must be greater than 0
+- `paymentTermsDays` must be one of 0, 14, 30, 60
+- **ROOT_FORM cross-field rule:** a business account with
+  `annualRevenue < 50000` may not request `requestedCreditLimit > 10000`
+  ("Credit limit exceeds policy for this revenue band")
+
+### Warnings — advisory only, never block submission (`warn()`)
+
+- `requestedCreditLimit > annualRevenue * 0.5` →
+  "Requested credit limit is high relative to revenue — expect manual review"
+- `paymentTermsDays >= 60` → "Long payment terms may slow onboarding"
+- `accountType === 'personal'` and `requestedCreditLimit > 5000` →
+  "Personal accounts above 5000 usually need a business upgrade"
+
+A form carrying only warnings still submits successfully — the page checks
+`formState().valid` (errors only) before accepting the submission.
+
+## Why Vest expresses this naturally
+
+- `omitWhen` keeps a conditional rule out of the suite entirely until its
+  precondition holds, so the VAT-ID error simply does not exist for personal or
+  non-EU accounts.
+- `ROOT_FORM` gives cross-field policy a single home rather than smearing it
+  across two field validators.
+- `warn()` flips a test from blocking to advisory with one call, so guidance
+  and hard failures share the same authoring model but are surfaced separately.
+- The suite is plain Vest: `businessPolicySuite(model)` can be asserted in a
+  unit test without rendering Angular.
+
+## ngx-vest-forms APIs showcased
+
+- `NgxVestForms`, `FormDirective`, `provideFormContract`
+- `createValidationConfig()` with `.whenChanged()` and `.bidirectional()`
+  (revalidates the conditional VAT-ID field and the revenue/credit-limit pair)
+- `createFormFeedbackSignals()` for `formState`, `warnings`,
+  `validatedFields`, `pending`
+- `ROOT_FORM`, `NgxVestSuite`, `NgxDeepPartial`, `NgxDeepRequired`
+- Vest `create`, `test`, `enforce`, `omitWhen`, `warn`
+
+## Key files
+
+- `business-policy.page.ts` / `.html` — page shell; owns the form value, suite
+  and validation config; gates submit on errors only
+- `business-policy.form.ts` / `.html` — form body; conditional VAT-ID field via
+  `@if`
+- `business-policy.validations.ts` — the Vest suite plus the error/warning
+  rule maps
+- `../../models/business-policy.model.ts` — model and contract

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.content.ts
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.content.ts
@@ -1,0 +1,37 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const businessPolicyContent = defineExampleContent({
+  demonstrates: {
+    icon: '📋',
+    title: 'What this demonstrates',
+    points: [
+      'Conditional rules with omitWhen: VAT ID is required only for EU-based business accounts',
+      'A cross-field ROOT_FORM policy: a sub-50k-revenue business may not request a credit limit above 10000',
+      'Advisory warn() guidance modelled separately from blocking errors — it never prevents submit',
+      'Dependency-aware revalidation via createValidationConfig (account/country ↔ VAT ID, revenue ↔ credit limit)',
+      'The same suite is plain Vest and unit-testable in isolation, with no Angular dependency',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Errors block, warnings advise',
+        points: [
+          'Errors gate submission; warn() tests surface guidance without blocking it',
+          'A form carrying only warnings still submits successfully',
+          'The form-state card shows the two categories side by side',
+        ],
+      },
+      {
+        title: 'Expressing policy in Vest',
+        points: [
+          'omitWhen keeps conditional rules out of the suite entirely until they apply',
+          'ROOT_FORM expresses cross-field business policy in one place',
+          'createValidationConfig revalidates dependent fields without manual wiring',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Purchase checkout', route: 'purchase' },
+  },
+});

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.form.html
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.form.html
@@ -1,0 +1,160 @@
+<ngx-card>
+  <form
+    ngxVestForm
+    #vestForm="ngxVestForm"
+    [suite]="suite()"
+    [formValue]="formValue()"
+    [validationConfig]="validationConfig()"
+    (formValueChange)="formValueChange.emit($event)"
+    (ngSubmit)="onSubmit()"
+    class="space-y-8"
+  >
+    <ngx-form-section
+      tone="blue"
+      title="Account"
+      description="Account type and legal identity. The VAT-ID field below appears only for EU-based business accounts."
+    >
+      <div class="space-y-6">
+        <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Account type</span>
+              <select
+                class="input-field"
+                id="accountType"
+                name="accountType"
+                [ngModel]="formValue().accountType"
+              >
+                <option value="">Select account type...</option>
+                <option value="personal">Personal</option>
+                <option value="business">Business</option>
+              </select>
+            </label>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Legal name</span>
+              <input
+                class="input-field"
+                type="text"
+                id="legalName"
+                name="legalName"
+                [ngModel]="formValue().legalName"
+                placeholder="e.g. Acme International B.V."
+                autocomplete="organization"
+              />
+            </label>
+          </ngx-control-wrapper>
+        </div>
+
+        <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Country</span>
+              <select
+                class="input-field"
+                id="country"
+                name="country"
+                [ngModel]="formValue().country"
+              >
+                <option value="">Select country...</option>
+                <option value="GB">United Kingdom (non-EU)</option>
+                <option value="US">United States (non-EU)</option>
+                @for (code of euCountries; track code) {
+                  <option [value]="code">{{ code }} (EU)</option>
+                }
+              </select>
+            </label>
+          </ngx-control-wrapper>
+
+          @if (
+            formValue().accountType === 'business' &&
+            isEuCountry(formValue().country)
+          ) {
+            <ngx-control-wrapper class="form-field animate-fade-in">
+              <label>
+                <span class="label-text">VAT ID</span>
+                <input
+                  class="input-field"
+                  type="text"
+                  id="vatId"
+                  name="vatId"
+                  [ngModel]="formValue().vatId"
+                  placeholder="e.g. NL123456789B01"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+              </label>
+            </ngx-control-wrapper>
+          }
+        </div>
+      </div>
+    </ngx-form-section>
+
+    <ngx-form-section
+      tone="teal"
+      title="Financials & terms"
+      description="These drive the cross-field policy rule and the advisory warnings. Warnings never block submit — only errors do."
+    >
+      <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+        <ngx-control-wrapper class="form-field">
+          <label>
+            <span class="label-text">Annual revenue</span>
+            <input
+              class="input-field"
+              type="number"
+              id="annualRevenue"
+              name="annualRevenue"
+              [ngModel]="formValue().annualRevenue"
+              placeholder="e.g. 75000"
+              inputmode="numeric"
+              min="0"
+            />
+          </label>
+        </ngx-control-wrapper>
+
+        <ngx-control-wrapper class="form-field">
+          <label>
+            <span class="label-text">Requested credit limit</span>
+            <input
+              class="input-field"
+              type="number"
+              id="requestedCreditLimit"
+              name="requestedCreditLimit"
+              [ngModel]="formValue().requestedCreditLimit"
+              placeholder="e.g. 8000"
+              inputmode="numeric"
+              min="0"
+            />
+          </label>
+        </ngx-control-wrapper>
+
+        <ngx-control-wrapper class="form-field">
+          <label>
+            <span class="label-text">Payment terms (days)</span>
+            <select
+              class="input-field"
+              id="paymentTermsDays"
+              name="paymentTermsDays"
+              [ngModel]="formValue().paymentTermsDays"
+            >
+              <option [ngValue]="undefined">Select payment terms...</option>
+              <option [ngValue]="0">0 (immediate)</option>
+              <option [ngValue]="14">14</option>
+              <option [ngValue]="30">30</option>
+              <option [ngValue]="60">60</option>
+            </select>
+          </label>
+        </ngx-control-wrapper>
+      </div>
+    </ngx-form-section>
+
+    <div class="flex justify-end gap-3 pt-4">
+      <button type="button" class="btn btn-secondary" (click)="onReset()">
+        Reset Form
+      </button>
+      <button type="submit" class="btn btn-primary">Submit Application</button>
+    </div>
+  </form>
+</ngx-card>

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.form.ts
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.form.ts
@@ -51,20 +51,16 @@ export class BusinessPolicyFormBody {
 
   private readonly vestForm =
     viewChild<FormDirective<BusinessPolicyModel>>('vestForm');
-  private readonly formFeedback = createFormFeedbackSignals(this.vestForm);
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
 
   /** Exposes the directive's packaged form state with up-to-date errors. */
-  readonly formState = this.formFeedback.formState;
-
+  
   /** Exposes field warnings as a plain Record for presentational components. */
-  readonly warnings = this.formFeedback.warnings;
-
+  
   /** Field paths that have been validated (touched/blurred or submitted). */
-  readonly validatedFields = this.formFeedback.validatedFields;
-
+  
   /** True while async validation is in progress. */
-  readonly pending = this.formFeedback.pending;
-
+  
   /** True when the EU country set contains the selected country. */
   protected isEuCountry(country: string | undefined): boolean {
     return !!country && (this.euCountries as readonly string[]).includes(

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.form.ts
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.form.ts
@@ -53,14 +53,6 @@ export class BusinessPolicyFormBody {
     viewChild<FormDirective<BusinessPolicyModel>>('vestForm');
   readonly feedback = createFormFeedbackSignals(this.vestForm);
 
-  /** Exposes the directive's packaged form state with up-to-date errors. */
-  
-  /** Exposes field warnings as a plain Record for presentational components. */
-  
-  /** Field paths that have been validated (touched/blurred or submitted). */
-  
-  /** True while async validation is in progress. */
-  
   /** True when the EU country set contains the selected country. */
   protected isEuCountry(country: string | undefined): boolean {
     return !!country && (this.euCountries as readonly string[]).includes(

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.form.ts
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.form.ts
@@ -1,0 +1,86 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxValidationConfig,
+  NgxVestForms,
+  NgxVestSuite,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  businessPolicyContract,
+  BusinessPolicyModel,
+} from '../../models/business-policy.model';
+import { Card } from '../../ui/card/card.component';
+import { FormSectionComponent } from '../../ui/form-section/form-section.component';
+import { EU_COUNTRIES } from './business-policy.validations';
+
+/**
+ * The form body for the business-policy demo.
+ *
+ * Mirrors the validation-config-demo split: the page owns the form value, the
+ * suite and the validation config; this component only renders fields and
+ * re-exposes the packaged feedback signals. The conditional VAT-ID field is
+ * shown with `@if` when the account is a business based in the EU.
+ */
+@Component({
+  selector: 'ngx-business-policy-form-body',
+  imports: [NgxVestForms, Card, FormSectionComponent],
+  templateUrl: './business-policy.form.html',
+  providers: [provideFormContract(businessPolicyContract)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BusinessPolicyFormBody {
+  readonly formValue = input.required<BusinessPolicyModel>();
+  readonly suite = input.required<NgxVestSuite<BusinessPolicyModel>>();
+  readonly validationConfig =
+    input.required<NgxValidationConfig<BusinessPolicyModel>>();
+
+  readonly formValueChange = output<BusinessPolicyModel>();
+  readonly submitted = output();
+  readonly resetRequested = output();
+
+  /** EU country options that trigger the conditional VAT-ID rule. */
+  protected readonly euCountries = EU_COUNTRIES;
+
+  private readonly vestForm =
+    viewChild<FormDirective<BusinessPolicyModel>>('vestForm');
+  private readonly formFeedback = createFormFeedbackSignals(this.vestForm);
+
+  /** Exposes the directive's packaged form state with up-to-date errors. */
+  readonly formState = this.formFeedback.formState;
+
+  /** Exposes field warnings as a plain Record for presentational components. */
+  readonly warnings = this.formFeedback.warnings;
+
+  /** Field paths that have been validated (touched/blurred or submitted). */
+  readonly validatedFields = this.formFeedback.validatedFields;
+
+  /** True while async validation is in progress. */
+  readonly pending = this.formFeedback.pending;
+
+  /** True when the EU country set contains the selected country. */
+  protected isEuCountry(country: string | undefined): boolean {
+    return !!country && (this.euCountries as readonly string[]).includes(
+      country
+    );
+  }
+
+  protected onSubmit(): void {
+    this.submitted.emit();
+  }
+
+  protected onReset(): void {
+    this.resetRequested.emit();
+  }
+
+  resetFormState(value: BusinessPolicyModel): void {
+    this.vestForm()?.resetForm(value);
+  }
+}

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.page.html
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.page.html
@@ -1,0 +1,65 @@
+<div class="page-container">
+  <ngx-page-title
+    title="Vest-First Business Policy"
+    subtitle="Conditional rules and advisory warnings that stay native to Vest — guidance modelled separately from errors."
+  />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
+  <ngx-form-page-layout>
+    <div layout-aside class="sidebar-card-stack">
+      <ngx-card title="Policy at a glance">
+        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-200">
+          <li>
+            <strong>Errors block submit:</strong> required fields, EU VAT ID,
+            credit-limit floor, allowed payment terms.
+          </li>
+          <li>
+            <strong>Cross-field rule:</strong> low-revenue business cannot
+            request a high credit limit (<code>ROOT_FORM</code>).
+          </li>
+          <li>
+            <strong>Warnings never block:</strong> advisory
+            <code>warn()</code> guidance about manual review.
+          </li>
+          <li>
+            <strong>Conditional VAT ID:</strong> shown only for EU-based
+            business accounts via <code>omitWhen</code> + <code>&#64;if</code>.
+          </li>
+        </ul>
+      </ngx-card>
+
+      <ngx-form-state-card
+        [formState]="formBody.formState()"
+        [warnings]="formBody.warnings()"
+        [errors]="formBody.formState().errors"
+        [validationErrorRules]="errorRules"
+        [validationWarningRules]="warningRules"
+        [validatedFields]="formBody.validatedFields()"
+        [pending]="formBody.pending()"
+      />
+    </div>
+
+    <div layout-main>
+      @if (submittedValue(); as submitted) {
+        <ngx-alert-panel tone="success" title="Application submitted">
+          <p>
+            Thanks — the application for
+            <strong>{{ submitted.legalName }}</strong> was accepted. Any
+            advisory warnings above did not block submission.
+          </p>
+        </ngx-alert-panel>
+      }
+
+      <ngx-business-policy-form-body
+        #formBody
+        [formValue]="formValue()"
+        [suite]="suite"
+        [validationConfig]="validationConfig"
+        (formValueChange)="formValue.set($event)"
+        (submitted)="onSubmit()"
+        (resetRequested)="reset()"
+      />
+    </div>
+  </ngx-form-page-layout>
+</div>

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.page.html
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.page.html
@@ -30,14 +30,11 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="formBody.formState()"
-        [warnings]="formBody.warnings()"
-        [errors]="formBody.formState().errors"
+        [feedback]="formBody.feedback"
+        [errors]="formBody.feedback.formState().errors"
         [validationErrorRules]="errorRules"
         [validationWarningRules]="warningRules"
-        [validatedFields]="formBody.validatedFields()"
-        [pending]="formBody.pending()"
-      />
+        />
     </div>
 
     <div layout-main>

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.page.ts
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.page.ts
@@ -1,0 +1,83 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { createValidationConfig } from 'ngx-vest-forms';
+import { BusinessPolicyModel } from '../../models/business-policy.model';
+import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
+import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
+import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
+import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { PageTitle } from '../../ui/page-title/page-title.component';
+import { businessPolicyContent } from './business-policy.content';
+import { BusinessPolicyFormBody } from './business-policy.form';
+import {
+  businessPolicyErrorRulesByField,
+  businessPolicySuite,
+  businessPolicyWarningRulesByField,
+} from './business-policy.validations';
+
+/**
+ * Vest-First Business Policy demo.
+ *
+ * The page owns the form value signal, the suite and the validation config
+ * (mirrors validation-config-demo). It showcases expressive conditional rules
+ * and non-blocking advisory guidance: errors gate submission, `warn()` tests
+ * never do. A form carrying only warnings still submits.
+ */
+@Component({
+  selector: 'ngx-business-policy-page',
+  imports: [
+    AlertPanel,
+    Card,
+    ExampleCardsComponent,
+    FormPageLayout,
+    FormStateCardComponent,
+    PageTitle,
+    BusinessPolicyFormBody,
+  ],
+  templateUrl: './business-policy.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class BusinessPolicyPageComponent {
+  protected readonly exampleContent = businessPolicyContent;
+  protected readonly suite = businessPolicySuite;
+  protected readonly errorRules = businessPolicyErrorRulesByField;
+  protected readonly warningRules = businessPolicyWarningRulesByField;
+
+  /** The form value is the single source of truth, owned by the page. */
+  protected readonly formValue = signal<BusinessPolicyModel>({});
+  protected readonly submittedValue = signal<BusinessPolicyModel | null>(null);
+
+  private readonly formBody = viewChild(BusinessPolicyFormBody);
+
+  /**
+   * Revalidate the conditional VAT-ID field whenever the inputs that gate it
+   * change, and keep the revenue/credit-limit pair in sync for the ROOT_FORM
+   * policy rule and the relative-size warning.
+   */
+  protected readonly validationConfig =
+    createValidationConfig<BusinessPolicyModel>()
+      .whenChanged('accountType', ['vatId', 'requestedCreditLimit'])
+      .whenChanged('country', 'vatId')
+      .bidirectional('annualRevenue', 'requestedCreditLimit')
+      .build();
+
+  protected onSubmit(): void {
+    // Warnings are advisory and never block submit — only errors gate it.
+    if (!this.formBody()?.formState()?.valid) {
+      this.submittedValue.set(null);
+      return;
+    }
+    this.submittedValue.set(structuredClone(this.formValue()));
+  }
+
+  protected reset(): void {
+    this.submittedValue.set(null);
+    this.formBody()?.resetFormState({});
+    this.formValue.set({});
+  }
+}

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.page.ts
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.page.ts
@@ -1,3 +1,4 @@
+import { computed } from "@angular/core";
 import {
   ChangeDetectionStrategy,
   Component,
@@ -43,6 +44,7 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class BusinessPolicyPageComponent {
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
   protected readonly exampleContent = businessPolicyContent;
   protected readonly suite = businessPolicySuite;
   protected readonly errorRules = businessPolicyErrorRulesByField;
@@ -68,7 +70,7 @@ export class BusinessPolicyPageComponent {
 
   protected onSubmit(): void {
     // Warnings are advisory and never block submit — only errors gate it.
-    if (!this.formBody()?.formState()?.valid) {
+    if (!this.feedback()?.formState()?.valid) {
       this.submittedValue.set(null);
       return;
     }

--- a/apps/examples/src/app/pages/business-policy-form/business-policy.validations.ts
+++ b/apps/examples/src/app/pages/business-policy-form/business-policy.validations.ts
@@ -1,0 +1,170 @@
+import { NgxVestSuite, ROOT_FORM } from 'ngx-vest-forms';
+import { create, enforce, omitWhen, test, warn } from 'vest';
+import { BusinessPolicyModel } from '../../models/business-policy.model';
+
+/**
+ * EU member-state country codes that trigger the conditional VAT-ID rule.
+ * A small representative set is enough for the demo.
+ */
+export const EU_COUNTRIES = [
+  'AT',
+  'BE',
+  'DE',
+  'ES',
+  'FR',
+  'IE',
+  'IT',
+  'NL',
+  'PL',
+  'SE',
+] as const;
+
+/** Allowed payment-term values, in days. */
+export const ALLOWED_PAYMENT_TERMS = [0, 14, 30, 60] as const;
+
+const isEuCountry = (country: string | undefined): boolean =>
+  !!country && (EU_COUNTRIES as readonly string[]).includes(country);
+
+/**
+ * The Vest suite for the business-policy form.
+ *
+ * It is a plain Vest spec — no Angular dependency — so it can be unit-tested in
+ * isolation by calling `businessPolicySuite(model)` directly. All policy logic
+ * lives here:
+ *
+ * - ERROR tests block submission (required fields, conditional VAT ID,
+ *   credit-limit floor, allowed payment terms, plus a cross-field ROOT_FORM
+ *   revenue-band rule).
+ * - WARN tests (`warn()`) are advisory only and never block submission — they
+ *   model "expect manual review" style guidance separately from hard errors.
+ */
+export const businessPolicySuite: NgxVestSuite<BusinessPolicyModel> = create(
+  (model: BusinessPolicyModel) => {
+    // ── Blocking errors ────────────────────────────────────────────────
+    test('accountType', 'Account type is required', () => {
+      enforce(model.accountType).isNotBlank();
+    });
+
+    test('legalName', 'Legal name is required', () => {
+      enforce(model.legalName).isNotBlank();
+    });
+
+    test('country', 'Country is required', () => {
+      enforce(model.country).isNotBlank();
+    });
+
+    // Conditional rule: VAT ID is required ONLY for business accounts based in
+    // the EU. omitWhen keeps the rule out of the suite entirely otherwise, so
+    // it never reports an error for personal or non-EU accounts.
+    omitWhen(
+      model.accountType !== 'business' || !isEuCountry(model.country),
+      () => {
+        test(
+          'vatId',
+          'VAT ID is required for EU-based business accounts',
+          () => {
+            enforce(model.vatId).isNotBlank();
+          }
+        );
+      }
+    );
+
+    test('requestedCreditLimit', 'Requested credit limit must be greater than 0', () => {
+      enforce(Number(model.requestedCreditLimit ?? 0)).greaterThan(0);
+    });
+
+    test(
+      'paymentTermsDays',
+      'Payment terms must be one of 0, 14, 30 or 60 days',
+      () => {
+        enforce(
+          (ALLOWED_PAYMENT_TERMS as readonly number[]).includes(
+            Number(model.paymentTermsDays)
+          )
+        ).isTruthy();
+      }
+    );
+
+    // Cross-field policy expressed as a ROOT_FORM error: a low-revenue business
+    // account cannot request a high credit limit.
+    omitWhen(model.accountType !== 'business', () => {
+      test(
+        ROOT_FORM,
+        'Credit limit exceeds policy for this revenue band',
+        () => {
+          const revenue = Number(model.annualRevenue ?? 0);
+          const creditLimit = Number(model.requestedCreditLimit ?? 0);
+          enforce(revenue < 50000 && creditLimit > 10000).isFalsy();
+        }
+      );
+    });
+
+    // ── Advisory warnings (never block submit) ────────────────────────
+    omitWhen(
+      !model.requestedCreditLimit || !model.annualRevenue,
+      () => {
+        test(
+          'requestedCreditLimit',
+          'Requested credit limit is high relative to revenue — expect manual review',
+          () => {
+            warn();
+            enforce(
+              Number(model.requestedCreditLimit ?? 0) >
+                Number(model.annualRevenue ?? 0) * 0.5
+            ).isFalsy();
+          }
+        );
+      }
+    );
+
+    omitWhen(!model.paymentTermsDays, () => {
+      test(
+        'paymentTermsDays',
+        'Long payment terms may slow onboarding',
+        () => {
+          warn();
+          enforce(Number(model.paymentTermsDays ?? 0)).lessThan(60);
+        }
+      );
+    });
+
+    omitWhen(model.accountType !== 'personal', () => {
+      test(
+        'requestedCreditLimit',
+        'Personal accounts above 5000 usually need a business upgrade',
+        () => {
+          warn();
+          enforce(Number(model.requestedCreditLimit ?? 0)).lessThanOrEquals(
+            5000
+          );
+        }
+      );
+    });
+  }
+);
+
+/**
+ * Blocking error rules per field path. Mirrors the auto-save-demo map; used by
+ * the form-state card to show the policy that hasn't been triggered yet.
+ */
+export const businessPolicyErrorRulesByField: Record<string, string[]> = {
+  accountType: ['Account type is required'],
+  legalName: ['Legal name is required'],
+  country: ['Country is required'],
+  vatId: ['VAT ID is required for EU-based business accounts'],
+  requestedCreditLimit: ['Requested credit limit must be greater than 0'],
+  paymentTermsDays: ['Payment terms must be one of 0, 14, 30 or 60 days'],
+  [ROOT_FORM]: ['Credit limit exceeds policy for this revenue band'],
+};
+
+/**
+ * Advisory (non-blocking) `warn()` rules per field path. These never prevent
+ * submission — they are surfaced separately from errors in the UI.
+ */
+export const businessPolicyWarningRulesByField: Record<string, string[]> = {
+  requestedCreditLimit: [
+    'Requested credit limit is high relative to revenue — expect manual review',
+    'Personal accounts above 5000 usually need a business upgrade',
+  ],
+  paymentTermsDays: ['Long payment terms may slow onboarding'],
+};

--- a/apps/examples/src/app/pages/complex-nested-form/README.md
+++ b/apps/examples/src/app/pages/complex-nested-form/README.md
@@ -1,0 +1,65 @@
+# Complex Nested & Repeatable Form
+
+A team-registration form that shows two patterns at once: **deep
+`ngModelGroup` nesting** and a **dynamic, repeatable collection** —
+assembled from small, reusable child components rather than one giant
+template.
+
+## Why this demo exists
+
+Real forms are rarely flat. They have nested sub-objects (an address inside
+a company) and lists that grow and shrink at runtime (team members). This
+demo proves both compose cleanly with ngx-vest-forms while keeping each
+piece independently understandable and testable.
+
+## What it shows
+
+- **Nested groups.** `company` is an `ngModelGroup`; inside it
+  `company.address` is another group rendered by the reusable
+  `ngx-address` component. No extra wiring — `vestFormsViewProviders` lets
+  the child register its controls into the parent form tree.
+- **Reusable child sections.** Each member's fields live in a tiny
+  `ngx-team-member` component whose only public contract is an
+  `input()` for the member value and an `idPrefix`. It mirrors
+  `ngx-address` exactly.
+- **Repeatable rows.** `teamMembers` is a `Record<string, TeamMemberModel>`
+  with contiguous numeric keys. Add/remove read the values as an array,
+  mutate, then `arrayToObject()` back — the canonical purchase-form pattern.
+  Handlers emit `(formValueChange)` immutably.
+- **Stable, deterministic keys.** Keys are a pure function of the current
+  model, so the stateless Vest suite re-keys to match the rendered
+  `ngModelGroup` names every run: validation refreshes correctly after a
+  structural change and a removed row's tests disappear with it.
+- **Round-trip on submit.** The page converts `teamMembers` back to a real
+  array with `objectToArray(value, ['teamMembers'])` — the JSON shape you'd
+  POST to a backend — and shows it in a payload card.
+- **Form-level rules.** A `ROOT_FORM` rule requires at least one member; a
+  non-blocking `warn()` advisory fires for teams larger than eight.
+- **Decomposition.** Model, suite, child component, form-body, and page are
+  separate modules with simple contracts.
+
+## Public API used
+
+`NgxVestForms`, `vestFormsViewProviders`, `FormDirective`,
+`provideFormContract`, `createFormFeedbackSignals`, `arrayToObject`,
+`objectToArray`, `NgxVestSuite`, `NgxDeepPartial`, `NgxDeepRequired`,
+`ROOT_FORM`. Vest primitives (`create`, `test`, `enforce`, `warn`) come
+from `vest`.
+
+## Key files
+
+| File | Responsibility |
+| --- | --- |
+| `complex-nested.page.ts` / `.html` | Page: owns formValue + add/remove + suite |
+| `complex-nested.form.ts` / `.html` | Form body: form tree + repeatable rows |
+| `team-member.component.ts` / `.html` | One member's fields (reusable child) |
+| `complex-nested.validations.ts` | Vest suite (testable in isolation) |
+| `../../models/complex-nested.model.ts` | Model + contract |
+| `complex-nested.content.ts` | "What this demonstrates / learn" cards |
+
+## Behavior
+
+Submitting while invalid keeps the success panel hidden and surfaces field
+errors. A valid submit shows a success panel echoing the company name and
+member count. Reset restores the initial single-member team and clears the
+panel.

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.content.ts
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.content.ts
@@ -1,0 +1,46 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const complexNestedContent = defineExampleContent({
+  demonstrates: {
+    icon: '🧩',
+    title: 'What this demonstrates',
+    points: [
+      'Deep ngModelGroup nesting: company → company.address driven by the reusable ngx-address',
+      'Reusable child sections (ngx-address, ngx-team-member) registering into one parent form tree via vestFormsViewProviders',
+      'A dynamic, repeatable teamMembers collection stored as an id-keyed record',
+      'Add/remove rows that mutate the keyed record immutably and emit (formValueChange)',
+      'Validation refreshing correctly after a structural change — removed rows drop their tests',
+      'A ROOT_FORM rule ("At least one team member is required") plus a warn() advisory for large teams',
+      'Decomposition into deep modules: model, suite, child component, form-body, and page',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Composing nested groups',
+        points: [
+          'How vestFormsViewProviders lets a child component register controls into the parent ngModelGroup',
+          'Why ngx-address can be reused under company.address with no extra wiring',
+          'Keeping child component contracts tiny: just an input() for the value and an id prefix',
+        ],
+      },
+      {
+        title: 'Repeatable rows that validate',
+        points: [
+          'Why stable, never-reused keys keep Vest field paths fixed across add/remove',
+          'Mutating a keyed record immutably and emitting it through (formValueChange)',
+          'Letting a removed row clear its own validation simply by disappearing from the model',
+        ],
+      },
+      {
+        title: 'Form-level rules',
+        points: [
+          'Using ROOT_FORM to require at least one member',
+          'Adding a non-blocking warn() advisory for oversized teams',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Business policy', route: 'business-policy' },
+  },
+});

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.form.html
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.form.html
@@ -1,0 +1,103 @@
+@if (submittedValue(); as submitted) {
+  <ngx-alert-panel tone="success" title="Team registered">
+    <p>
+      Registered
+      <strong>{{ submitted.company?.name }}</strong> with
+      {{ ((submitted.teamMembers ?? {}) | keyvalue).length }} team member(s).
+    </p>
+  </ngx-alert-panel>
+}
+
+<form
+  ngxVestForm
+  #vestForm="ngxVestForm"
+  (ngSubmit)="onSubmit()"
+  [formValue]="formValue()"
+  ngxValidateRootForm
+  [ngxValidateRootFormMode]="'submit'"
+  [suite]="suite()"
+  (formValueChange)="formValueChange.emit($event)"
+>
+  <div class="form-shell form-stack">
+    <ngx-form-section title="Company" tone="neutral">
+      <ngx-form-group-wrapper class="form-stack" ngModelGroup="company">
+        <ngx-control-wrapper class="form-field form-grid-full">
+          <label class="label-text" for="company-name">Company name</label>
+          <input
+            id="company-name"
+            class="input-field"
+            placeholder="Acme Corp"
+            type="text"
+            [ngModel]="formValue().company?.name"
+            name="name"
+            autocomplete="organization"
+          />
+        </ngx-control-wrapper>
+
+        <div class="form-divider" aria-hidden="true"></div>
+
+        <ngx-form-group-wrapper class="form-field" ngModelGroup="address">
+          <h3 class="section-title">Headquarters address</h3>
+          <ngx-address
+            idPrefix="company-hq"
+            [address]="formValue().company?.address"
+          />
+        </ngx-form-group-wrapper>
+      </ngx-form-group-wrapper>
+    </ngx-form-section>
+
+    <div class="form-divider" aria-hidden="true"></div>
+
+    <ngx-form-section title="Team members" tone="neutral">
+      <div class="form-stack">
+        <ngx-form-group-wrapper class="form-stack" ngModelGroup="teamMembers">
+          @for (entry of memberEntries(); track entry[0]) {
+            <ngx-form-group-wrapper
+              class="form-field rounded-lg border border-gray-200 p-4 dark:border-gray-700"
+              [ngModelGroup]="entry[0]"
+            >
+              <div class="mb-3 flex items-center justify-between gap-2">
+                <h3 class="section-title">
+                  Member {{ $index + 1 }}
+                </h3>
+                <button
+                  type="button"
+                  class="btn-input-action btn-input-action-danger"
+                  (click)="removeMember(entry[0])"
+                  [attr.aria-label]="'Remove member ' + ($index + 1)"
+                >
+                  Remove
+                </button>
+              </div>
+              <ngx-team-member
+                [idPrefix]="memberIdPrefix(entry[0])"
+                [member]="entry[1]"
+              />
+            </ngx-form-group-wrapper>
+          } @empty {
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              No team members yet. Add at least one to register the team.
+            </p>
+          }
+        </ngx-form-group-wrapper>
+
+        <div>
+          <button
+            type="button"
+            class="btn btn-secondary"
+            (click)="addMember()"
+          >
+            Add member
+          </button>
+        </div>
+      </div>
+    </ngx-form-section>
+
+    <div class="form-actions">
+      <button type="button" (click)="onReset()" class="btn btn-secondary">
+        Reset
+      </button>
+      <button type="submit" class="btn btn-primary">Register team</button>
+    </div>
+  </div>
+</form>

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.form.ts
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.form.ts
@@ -54,14 +54,6 @@ export class ComplexNestedFormBody {
     viewChild<FormDirective<ComplexNestedModel>>('vestForm');
   readonly feedback = createFormFeedbackSignals(this.vestForm);
 
-  /** Exposes the directive's packaged form state with up-to-date errors. */
-  
-  /** Exposes field warnings as a plain Record for presentational components. */
-  
-  /** Field paths that have been validated (touched/blurred or submitted). */
-  
-  /** True while async validation is in progress. */
-  
   /**
    * Ordered list of `[key, member]` pairs for the @for loop. Keys are a pure
    * function of the current model (contiguous numeric), so the stateless Vest

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.form.ts
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.form.ts
@@ -52,20 +52,16 @@ export class ComplexNestedFormBody {
 
   private readonly vestForm =
     viewChild<FormDirective<ComplexNestedModel>>('vestForm');
-  private readonly formFeedback = createFormFeedbackSignals(this.vestForm);
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
 
   /** Exposes the directive's packaged form state with up-to-date errors. */
-  readonly formState = this.formFeedback.formState;
-
+  
   /** Exposes field warnings as a plain Record for presentational components. */
-  readonly warnings = this.formFeedback.warnings;
-
+  
   /** Field paths that have been validated (touched/blurred or submitted). */
-  readonly validatedFields = this.formFeedback.validatedFields;
-
+  
   /** True while async validation is in progress. */
-  readonly pending = this.formFeedback.pending;
-
+  
   /**
    * Ordered list of `[key, member]` pairs for the @for loop. Keys are a pure
    * function of the current model (contiguous numeric), so the stateless Vest

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.form.ts
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.form.ts
@@ -1,0 +1,127 @@
+import { KeyValuePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import {
+  arrayToObject,
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxVestForms,
+  NgxVestSuite,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  ComplexNestedModel,
+  complexNestedContract,
+  TeamMemberModel,
+} from '../../models/complex-nested.model';
+import { AddressComponent } from '../../ui/address/address.component';
+import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
+import { FormSectionComponent } from '../../ui/form-section/form-section.component';
+import { TeamMemberComponent } from './team-member.component';
+
+const emptyMember: TeamMemberModel = { fullName: '', email: '', role: '' };
+
+@Component({
+  selector: 'ngx-complex-nested-form-body',
+  imports: [
+    NgxVestForms,
+    KeyValuePipe,
+    AlertPanel,
+    AddressComponent,
+    FormSectionComponent,
+    TeamMemberComponent,
+  ],
+  templateUrl: './complex-nested.form.html',
+  providers: [provideFormContract(complexNestedContract)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ComplexNestedFormBody {
+  readonly formValue = input.required<ComplexNestedModel>();
+  readonly suite = input.required<NgxVestSuite<ComplexNestedModel>>();
+  readonly submittedValue = input<ComplexNestedModel | null>(null);
+
+  readonly formValueChange = output<ComplexNestedModel>();
+  readonly submitted = output();
+  readonly resetRequested = output();
+
+  private readonly vestForm =
+    viewChild<FormDirective<ComplexNestedModel>>('vestForm');
+  private readonly formFeedback = createFormFeedbackSignals(this.vestForm);
+
+  /** Exposes the directive's packaged form state with up-to-date errors. */
+  readonly formState = this.formFeedback.formState;
+
+  /** Exposes field warnings as a plain Record for presentational components. */
+  readonly warnings = this.formFeedback.warnings;
+
+  /** Field paths that have been validated (touched/blurred or submitted). */
+  readonly validatedFields = this.formFeedback.validatedFields;
+
+  /** True while async validation is in progress. */
+  readonly pending = this.formFeedback.pending;
+
+  /**
+   * Ordered list of `[key, member]` pairs for the @for loop. Keys are a pure
+   * function of the current model (contiguous numeric), so the stateless Vest
+   * suite re-keys to match the rendered ngModelGroup names on every run.
+   */
+  protected readonly memberEntries = computed(() =>
+    Object.entries(this.formValue().teamMembers ?? {})
+  );
+
+  protected onSubmit(): void {
+    this.submitted.emit();
+  }
+
+  protected onReset(): void {
+    this.resetRequested.emit();
+  }
+
+  resetFormState(value: ComplexNestedModel): void {
+    this.vestForm()?.resetForm(value);
+  }
+
+  /**
+   * Appends a new member. Mirrors the purchase form's repeatable pattern:
+   * take the current values as an array, mutate, then `arrayToObject` back to
+   * a contiguous numeric-keyed record. Keys stay deterministic for the model
+   * state, so the stateless suite re-keys to match the rendered groups.
+   */
+  protected addMember(): void {
+    const current = this.formValue();
+    const members = [
+      ...Object.values(current.teamMembers ?? {}),
+      { ...emptyMember },
+    ];
+    this.formValueChange.emit({
+      ...current,
+      teamMembers: arrayToObject(members),
+    });
+  }
+
+  /**
+   * Removes a member by index, then re-keys the remaining members with
+   * `arrayToObject`. The suite reads current keys on every run, so the
+   * removed row's Vest tests disappear and the rest stay valid.
+   */
+  protected removeMember(key: string): void {
+    const current = this.formValue();
+    const members = Object.values(current.teamMembers ?? {}).filter(
+      (_, index) => index !== Number(key)
+    );
+    this.formValueChange.emit({
+      ...current,
+      teamMembers: arrayToObject(members),
+    });
+  }
+
+  protected memberIdPrefix(key: string): string {
+    return `team-member-${key}`;
+  }
+}

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.page.html
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.page.html
@@ -1,0 +1,53 @@
+<div class="page-container">
+  <ngx-page-title
+    title="Complex Nested & Repeatable Form"
+    subtitle="Nested ngModelGroup sections and dynamic add/remove rows composed from reusable child components."
+  />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
+  <ngx-form-page-layout>
+    <div layout-aside class="sidebar-card-stack">
+      <ngx-card title="Key features">
+        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-200">
+          <li>
+            Deep <code>ngModelGroup</code> nesting:
+            <code>company.address</code>.
+          </li>
+          <li>Reusable <code>ngx-address</code> &amp; child member sections.</li>
+          <li>Repeatable rows in a stable id-keyed record.</li>
+          <li>Validation refreshes correctly after add/remove.</li>
+          <li><code>ROOT_FORM</code> rule + non-blocking warning.</li>
+        </ul>
+      </ngx-card>
+
+      <ngx-form-state-card
+        [formState]="formBody.formState()"
+        [warnings]="formBody.warnings()"
+        [validatedFields]="formBody.validatedFields()"
+        [pending]="formBody.pending()"
+      />
+    </div>
+
+    <div layout-main>
+      <ngx-complex-nested-form-body
+        #formBody
+        [formValue]="formValue()"
+        [suite]="suite"
+        [submittedValue]="submittedValue()"
+        (formValueChange)="onFormValueChange($event)"
+        (submitted)="onSubmit()"
+        (resetRequested)="onReset()"
+      />
+
+      @if (submittedPayload(); as payload) {
+        <ngx-card
+          title="Submitted payload"
+          subtitle="teamMembers converted back to an array with objectToArray() — the shape you'd POST to a backend."
+        >
+          <ngx-json-preview title="Payload" [value]="payload" />
+        </ngx-card>
+      }
+    </div>
+  </ngx-form-page-layout>
+</div>

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.page.html
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.page.html
@@ -22,11 +22,8 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="formBody.formState()"
-        [warnings]="formBody.warnings()"
-        [validatedFields]="formBody.validatedFields()"
-        [pending]="formBody.pending()"
-      />
+        [feedback]="formBody.feedback"
+        />
     </div>
 
     <div layout-main>

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.page.ts
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.page.ts
@@ -1,3 +1,4 @@
+import { computed } from "@angular/core";
 import {
   ChangeDetectionStrategy,
   Component,
@@ -42,6 +43,7 @@ import { complexNestedSuite } from './complex-nested.validations';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ComplexNestedPageComponent {
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
   protected readonly exampleContent = complexNestedContent;
   protected readonly suite = complexNestedSuite;
 
@@ -65,7 +67,7 @@ export class ComplexNestedPageComponent {
   }
 
   protected onSubmit(): void {
-    if (!this.formBody()?.formState()?.valid) {
+    if (!this.feedback()?.formState()?.valid) {
       this.submittedValue.set(null);
       this.submittedPayload.set(null);
       return;

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.page.ts
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.page.ts
@@ -1,0 +1,84 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { objectToArray } from 'ngx-vest-forms';
+import {
+  ComplexNestedModel,
+  initialComplexNestedValue,
+} from '../../models/complex-nested.model';
+import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
+import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
+import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { JsonPreviewComponent } from '../../ui/json-preview/json-preview.component';
+import { PageTitle } from '../../ui/page-title/page-title.component';
+import { complexNestedContent } from './complex-nested.content';
+import { ComplexNestedFormBody } from './complex-nested.form';
+import { complexNestedSuite } from './complex-nested.validations';
+
+/**
+ * Team-registration demo: deep ngModelGroup nesting plus a dynamic,
+ * repeatable id-keyed collection, composed from reusable child components.
+ *
+ * The page owns the `formValue` signal (single source of truth) and the
+ * add/remove handlers; the form-body component renders the form tree and
+ * exposes packaged form state.
+ */
+@Component({
+  selector: 'ngx-complex-nested-page',
+  imports: [
+    PageTitle,
+    Card,
+    FormPageLayout,
+    FormStateCardComponent,
+    ExampleCardsComponent,
+    JsonPreviewComponent,
+    ComplexNestedFormBody,
+  ],
+  templateUrl: './complex-nested.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ComplexNestedPageComponent {
+  protected readonly exampleContent = complexNestedContent;
+  protected readonly suite = complexNestedSuite;
+
+  /** The form value is the single source of truth, owned by the page. */
+  protected readonly formValue = signal<ComplexNestedModel>(
+    initialComplexNestedValue
+  );
+  protected readonly submittedValue = signal<ComplexNestedModel | null>(null);
+
+  /**
+   * The submitted payload with `teamMembers` converted from a numeric-keyed
+   * record back to a real array via `objectToArray` — the shape you'd send
+   * to a backend (same round-trip the purchase form uses).
+   */
+  protected readonly submittedPayload = signal<unknown | null>(null);
+
+  private readonly formBody = viewChild(ComplexNestedFormBody);
+
+  protected onFormValueChange(value: ComplexNestedModel): void {
+    this.formValue.set(value);
+  }
+
+  protected onSubmit(): void {
+    if (!this.formBody()?.formState()?.valid) {
+      this.submittedValue.set(null);
+      this.submittedPayload.set(null);
+      return;
+    }
+    const value = structuredClone(this.formValue());
+    this.submittedValue.set(value);
+    this.submittedPayload.set(objectToArray(value, ['teamMembers']));
+  }
+
+  protected onReset(): void {
+    this.submittedValue.set(null);
+    this.submittedPayload.set(null);
+    this.formValue.set(initialComplexNestedValue);
+    this.formBody()?.resetFormState(initialComplexNestedValue);
+  }
+}

--- a/apps/examples/src/app/pages/complex-nested-form/complex-nested.validations.ts
+++ b/apps/examples/src/app/pages/complex-nested-form/complex-nested.validations.ts
@@ -1,0 +1,56 @@
+import { NgxVestSuite, ROOT_FORM } from 'ngx-vest-forms';
+import { create, enforce, test, warn } from 'vest';
+import { ComplexNestedModel } from '../../models/complex-nested.model';
+import { addressValidations } from '../../shared/validations/address.validations';
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Vest suite for the team-registration form.
+ *
+ * The suite is stateless: it simply reads the current model on each run. Since
+ * `teamMembers` is keyed by a stable id (never re-indexed on remove), each
+ * member's field paths stay constant, so add/remove refreshes validation
+ * correctly and a removed row's tests disappear with its key.
+ */
+export const complexNestedSuite: NgxVestSuite<ComplexNestedModel> = create(
+  (model: ComplexNestedModel) => {
+    const memberEntries = Object.entries(model.teamMembers ?? {});
+
+    test(ROOT_FORM, 'At least one team member is required', () => {
+      enforce(memberEntries.length).greaterThan(0);
+    });
+
+    test(ROOT_FORM, 'Large teams are harder to manage — keep it under 9', () => {
+      warn();
+      enforce(memberEntries.length).lessThanOrEquals(8);
+    });
+
+    test('company.name', 'Company name is required', () => {
+      enforce(model.company?.name).isNotBlank();
+    });
+
+    addressValidations(model.company?.address, 'company.address');
+
+    for (const [key, member] of memberEntries) {
+      test(
+        `teamMembers.${key}.fullName`,
+        'Full name is required',
+        () => {
+          enforce(member?.fullName).isNotBlank();
+        }
+      );
+
+      test(`teamMembers.${key}.email`, 'Email is required', () => {
+        enforce(member?.email).isNotBlank();
+      });
+      test(`teamMembers.${key}.email`, 'Enter a valid email address', () => {
+        enforce(member?.email ?? '').matches(EMAIL_PATTERN);
+      });
+
+      test(`teamMembers.${key}.role`, 'Role is required', () => {
+        enforce(member?.role).isNotBlank();
+      });
+    }
+  }
+);

--- a/apps/examples/src/app/pages/complex-nested-form/team-member.component.html
+++ b/apps/examples/src/app/pages/complex-nested-form/team-member.component.html
@@ -1,0 +1,41 @@
+<div class="form-grid">
+  <ngx-control-wrapper class="form-field form-grid-full">
+    <label class="label-text" [attr.for]="fieldIds().fullName">Full name</label>
+    <input
+      [id]="fieldIds().fullName"
+      class="input-field"
+      placeholder="Ada Lovelace"
+      type="text"
+      [ngModel]="member()?.fullName"
+      name="fullName"
+      autocomplete="name"
+    />
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label class="label-text" [attr.for]="fieldIds().email">Email</label>
+    <input
+      [id]="fieldIds().email"
+      class="input-field"
+      placeholder="ada@example.com"
+      type="email"
+      [ngModel]="member()?.email"
+      name="email"
+      autocomplete="email"
+      inputmode="email"
+      spellcheck="false"
+    />
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label class="label-text" [attr.for]="fieldIds().role">Role</label>
+    <input
+      [id]="fieldIds().role"
+      class="input-field"
+      placeholder="Engineer"
+      type="text"
+      [ngModel]="member()?.role"
+      name="role"
+    />
+  </ngx-control-wrapper>
+</div>

--- a/apps/examples/src/app/pages/complex-nested-form/team-member.component.ts
+++ b/apps/examples/src/app/pages/complex-nested-form/team-member.component.ts
@@ -1,0 +1,37 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+import { NgxVestForms, vestFormsViewProviders } from 'ngx-vest-forms';
+import { TeamMemberModel } from '../../models/complex-nested.model';
+
+/**
+ * One team member's fields.
+ *
+ * Uses `vestFormsViewProviders` exactly like `ngx-address` so the inner
+ * `[ngModel]` controls register against the parent form's `ngModelGroup`
+ * (the host renders this inside `<ngx-form-group-wrapper ngModelGroup="...">`).
+ * The component owns no state — values flow up via ngModel automatically.
+ */
+@Component({
+  selector: 'ngx-team-member',
+  imports: [NgxVestForms],
+  templateUrl: './team-member.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  viewProviders: [vestFormsViewProviders],
+})
+export class TeamMemberComponent {
+  /** This member's current value (read-only projection of the parent model). */
+  readonly member = input<TeamMemberModel>();
+
+  /** Stable id used to build unique input `id`/`for` pairs. */
+  readonly idPrefix = input.required<string>();
+
+  protected readonly fieldIds = computed(() => ({
+    fullName: `${this.idPrefix()}-fullName`,
+    email: `${this.idPrefix()}-email`,
+    role: `${this.idPrefix()}-role`,
+  }));
+}

--- a/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.content.ts
+++ b/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.content.ts
@@ -1,0 +1,35 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const conditionalStructureContent = defineExampleContent({
+  demonstrates: {
+    icon: '🧹',
+    title: 'What this demonstrates',
+    points: [
+      'clearFieldsWhen() removes stale values when a conditional input disappears or becomes irrelevant.',
+      'keepFieldsWhen() derives a backend-ready payload preview that keeps only the fields the current branch actually uses.',
+      'triggerFormValidation() re-runs validation right after structural changes so the active branch stays honest.',
+      'Vest omitWhen() keeps the suite aligned with the same delivery-mode branching used by the template.',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Conditional inputs without stale state',
+        points: [
+          'Use clearFieldsWhen() when switching branches so hidden fields do not keep old values.',
+          'Pair the same branch logic with omitWhen() so the suite and the UI agree.',
+          'Call triggerFormValidation() after structural changes to refresh the active branch immediately.',
+        ],
+      },
+      {
+        title: 'Payload shaping',
+        points: [
+          'Use keepFieldsWhen() to build the exact payload you would send to a backend.',
+          'Preview the shaped payload while editing so the behavior is easy to inspect and test.',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Submission patterns', route: 'submission-patterns' },
+  },
+});

--- a/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.form.html
+++ b/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.form.html
@@ -1,0 +1,80 @@
+<form
+  ngxVestForm
+  #vestForm="ngxVestForm"
+  [suite]="suite()"
+  [formValue]="formValue()"
+  (formValueChange)="formValueChange.emit($event)"
+  (ngSubmit)="onSubmit()"
+  class="space-y-6"
+>
+  <ngx-control-wrapper class="form-field">
+    <label for="contactName" class="label-text">Contact name</label>
+    <input
+      class="input-field"
+      type="text"
+      id="contactName"
+      name="contactName"
+      [ngModel]="formValue().contactName"
+      autocomplete="name"
+      placeholder="Ada Lovelace"
+    />
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label for="deliveryMode" class="label-text">Delivery method</label>
+    <select
+      class="input-field"
+      id="deliveryMode"
+      name="deliveryMode"
+      [ngModel]="formValue().deliveryMode ?? 'pickup'"
+    >
+      <option value="pickup">Pickup</option>
+      <option value="shipment">Shipment</option>
+      <option value="digital">Digital delivery</option>
+    </select>
+  </ngx-control-wrapper>
+
+  @if (formValue().deliveryMode === 'shipment') {
+    <ngx-control-wrapper class="form-field">
+      <label for="shippingAddress" class="label-text">Shipping address</label>
+      <input
+        class="input-field"
+        type="text"
+        id="shippingAddress"
+        name="shippingAddress"
+        [ngModel]="formValue().shippingAddress"
+        autocomplete="street-address"
+        placeholder="123 Analytical Engine Way"
+      />
+    </ngx-control-wrapper>
+  } @else if (formValue().deliveryMode === 'digital') {
+    <ngx-control-wrapper class="form-field">
+      <label for="deliveryEmail" class="label-text">Delivery email</label>
+      <input
+        class="input-field"
+        type="email"
+        id="deliveryEmail"
+        name="deliveryEmail"
+        [ngModel]="formValue().deliveryEmail"
+        autocomplete="email"
+        inputmode="email"
+        placeholder="ada@example.com"
+      />
+    </ngx-control-wrapper>
+  } @else {
+    <div
+      class="rounded-xl border border-dashed border-sky-300 bg-sky-50/80 px-4 py-3 text-sm text-sky-900 dark:border-sky-700 dark:bg-sky-950/40 dark:text-sky-100"
+    >
+      No extra delivery field is required for pickup orders.
+    </div>
+  }
+
+  <div class="flex justify-end gap-3 pt-2">
+    <button type="button" class="btn btn-secondary" (click)="onReset()">
+      Reset
+    </button>
+    <button type="submit" class="btn btn-primary">
+      Save delivery plan
+    </button>
+  </div>
+</form>

--- a/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.form.ts
+++ b/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.form.ts
@@ -1,0 +1,59 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxVestForms,
+  NgxVestSuite,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  ConditionalStructureModel,
+  conditionalStructureContract,
+} from '../../models/conditional-structure.model';
+
+@Component({
+  selector: 'ngx-conditional-structure-form-body',
+  imports: [NgxVestForms],
+  templateUrl: './conditional-structure.form.html',
+  providers: [provideFormContract(conditionalStructureContract)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConditionalStructureFormBody {
+  readonly formValue = input.required<ConditionalStructureModel>();
+  readonly suite = input.required<NgxVestSuite<ConditionalStructureModel>>();
+
+  readonly formValueChange = output<ConditionalStructureModel>();
+  readonly submitted = output();
+  readonly resetRequested = output();
+
+  private readonly vestForm =
+    viewChild<FormDirective<ConditionalStructureModel>>('vestForm');
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+        
+  protected onSubmit(): void {
+    this.submitted.emit();
+  }
+
+  protected onReset(): void {
+    this.resetRequested.emit();
+  }
+
+  resetFormState(value: ConditionalStructureModel): void {
+    this.vestForm()?.resetForm(value);
+  }
+
+  focusFirstInvalidControl(): void {
+    this.vestForm()?.focusFirstInvalidControl();
+  }
+
+  triggerValidation(): void {
+    this.vestForm()?.triggerFormValidation();
+  }
+}

--- a/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.page.html
+++ b/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.page.html
@@ -1,0 +1,71 @@
+<div class="page-container">
+  <ngx-page-title
+    title="Conditional Structure & Field Clearing"
+    subtitle="Keep model state and validation aligned when inputs disappear or turn into static content."
+  />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
+  <ngx-form-page-layout>
+    <div layout-aside class="sidebar-card-stack">
+      <ngx-card title="What changes when you switch modes">
+        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-200">
+          <li>
+            <code>shipment</code> keeps <code>shippingAddress</code> active.
+          </li>
+          <li>
+            <code>digital</code> swaps that field for <code>deliveryEmail</code>.
+          </li>
+          <li>
+            <code>pickup</code> removes the extra input entirely and leaves only
+            static guidance.
+          </li>
+          <li>
+            The payload preview keeps only the fields relevant to the active
+            branch.
+          </li>
+        </ul>
+      </ngx-card>
+
+      <ngx-form-state-card [feedback]="feedback()" />
+
+      <ngx-card
+        title="Relevant payload"
+        subtitle="Derived with keepFieldsWhen() so it mirrors what you would actually send to a backend."
+      >
+        <ngx-json-preview title="Payload preview" [value]="payloadPreview()" />
+      </ngx-card>
+    </div>
+
+    <div layout-main>
+      @if (submittedPayload(); as payload) {
+        <ngx-alert-panel tone="success" title="Delivery plan submitted">
+          <p>
+            The current branch is valid and the submitted payload has been
+            filtered to match it.
+          </p>
+        </ngx-alert-panel>
+
+        <ngx-card
+          title="Submitted payload"
+          subtitle="This snapshot is captured from the filtered preview, not the raw form object."
+        >
+          <ngx-json-preview title="Submitted payload" [value]="payload" />
+        </ngx-card>
+      }
+
+      <ngx-card
+        title="Delivery setup"
+        subtitle="Switch between a shipping input, a digital-delivery input, and a static pickup branch."
+      >
+        <ngx-conditional-structure-form-body
+          [formValue]="formValue()"
+          [suite]="suite"
+          (formValueChange)="onFormValueChange($event)"
+          (submitted)="onSubmit()"
+          (resetRequested)="reset()"
+        />
+      </ngx-card>
+    </div>
+  </ngx-form-page-layout>
+</div>

--- a/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.page.ts
+++ b/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.page.ts
@@ -1,0 +1,110 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {
+  clearFieldsWhen,
+  createEmptyFormState,
+  keepFieldsWhen,
+} from 'ngx-vest-forms';
+import {
+  ConditionalStructureModel,
+  DeliveryMode,
+  initialConditionalStructureValue,
+} from '../../models/conditional-structure.model';
+import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
+import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
+import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
+import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { JsonPreviewComponent } from '../../ui/json-preview/json-preview.component';
+import { PageTitle } from '../../ui/page-title/page-title.component';
+import { conditionalStructureContent } from './conditional-structure.content';
+import { ConditionalStructureFormBody } from './conditional-structure.form';
+import { conditionalStructureSuite } from './conditional-structure.validations';
+
+@Component({
+  selector: 'ngx-conditional-structure-page',
+  imports: [
+    PageTitle,
+    Card,
+    AlertPanel,
+    ExampleCardsComponent,
+    FormPageLayout,
+    FormStateCardComponent,
+    JsonPreviewComponent,
+    ConditionalStructureFormBody,
+  ],
+  templateUrl: './conditional-structure.page.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConditionalStructurePageComponent {
+  protected readonly exampleContent = conditionalStructureContent;
+  protected readonly suite = conditionalStructureSuite;
+  protected readonly formValue = signal<ConditionalStructureModel>(
+    initialConditionalStructureValue
+  );
+  protected readonly submittedPayload = signal<ConditionalStructureModel | null>(
+    null
+  );
+
+  private readonly formBody = viewChild(ConditionalStructureFormBody);
+
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
+  protected readonly payloadPreview = computed(() => {
+    const deliveryMode = this.formValue().deliveryMode ?? 'pickup';
+
+    return keepFieldsWhen(this.formValue(), {
+      contactName: true,
+      deliveryMode: true,
+      shippingAddress: deliveryMode === 'shipment',
+      deliveryEmail: deliveryMode === 'digital',
+    });
+  });
+
+  protected onFormValueChange(value: ConditionalStructureModel): void {
+    const previousDeliveryMode = this.formValue().deliveryMode ?? 'pickup';
+    const nextDeliveryMode = this.asDeliveryMode(value.deliveryMode ?? 'pickup');
+
+    this.formValue.set(
+      clearFieldsWhen(
+        {
+          ...value,
+          deliveryMode: nextDeliveryMode,
+        },
+        {
+          shippingAddress: nextDeliveryMode !== 'shipment',
+          deliveryEmail: nextDeliveryMode !== 'digital',
+        }
+      )
+    );
+
+    if (previousDeliveryMode !== nextDeliveryMode) {
+      this.submittedPayload.set(null);
+      this.formBody()?.triggerValidation();
+    }
+  }
+
+  protected onSubmit(): void {
+    if (!this.feedback()?.formState()?.valid) {
+      this.submittedPayload.set(null);
+      this.formBody()?.focusFirstInvalidControl();
+      return;
+    }
+
+    this.submittedPayload.set(structuredClone(this.payloadPreview()));
+  }
+
+  protected reset(): void {
+    this.submittedPayload.set(null);
+    this.formBody()?.resetFormState(initialConditionalStructureValue);
+    this.formValue.set(initialConditionalStructureValue);
+  }
+
+  private asDeliveryMode(value: string): DeliveryMode {
+    return value === 'shipment' || value === 'digital' ? value : 'pickup';
+  }
+}

--- a/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.validations.ts
+++ b/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.validations.ts
@@ -1,0 +1,34 @@
+import type { NgxVestSuite } from 'ngx-vest-forms';
+import { create, enforce, omitWhen, test } from 'vest';
+import { ConditionalStructureModel } from '../../models/conditional-structure.model';
+
+export const conditionalStructureSuite: NgxVestSuite<ConditionalStructureModel> =
+  create((model: ConditionalStructureModel) => {
+    test('contactName', 'Contact name is required', () => {
+      enforce(model.contactName).isNotBlank();
+    });
+
+    test('deliveryMode', 'Delivery method is required', () => {
+      enforce(model.deliveryMode).isNotBlank();
+    });
+
+    omitWhen(model.deliveryMode !== 'shipment', () => {
+      test('shippingAddress', 'Shipping address is required', () => {
+        enforce(model.shippingAddress).isNotBlank();
+      });
+    });
+
+    omitWhen(model.deliveryMode !== 'digital', () => {
+      test('deliveryEmail', 'Delivery email is required', () => {
+        enforce(model.deliveryEmail).isNotBlank();
+      });
+
+      omitWhen(!model.deliveryEmail, () => {
+        test('deliveryEmail', 'Enter a valid delivery email', () => {
+          enforce(model.deliveryEmail ?? '').matches(
+            /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+          );
+        });
+      });
+    });
+  });

--- a/apps/examples/src/app/pages/custom-controls-form/README.md
+++ b/apps/examples/src/app/pages/custom-controls-form/README.md
@@ -1,0 +1,60 @@
+# Custom Controls (ControlValueAccessor)
+
+Proves that a non-native control built on Angular's `ControlValueAccessor`
+participates in an ngx-vest-forms form exactly like a native `<input>` —
+validation, Vest warnings, touched state, and submission all work unchanged.
+
+## Why this demo exists
+
+Real apps rarely use only native inputs. This demo shows that ngx-vest-forms
+needs nothing special from a custom widget beyond the standard CVA contract:
+register through `NG_VALUE_ACCESSOR` and bind with `[ngModel]`.
+
+## What it shows
+
+- Three standalone custom controls, each implementing
+  `writeValue` / `registerOnChange` / `registerOnTouched` /
+  `setDisabledState` and provided via
+  `{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(...), multi: true }`:
+  - `ngx-star-rating` — 1–5 star buttons emitting a `number`.
+  - `ngx-segmented-control` — single-select for the `experience` string.
+  - `ngx-tag-input` — inline tag editor emitting a `string[]`.
+- Each control bound with plain `[ngModel]` and `name="…"` inside
+  `ngx-control-wrapper`, so errors and warnings render automatically.
+- A plain Vest suite (`custom-controls.validations.ts`): `rating` required and
+  between 1 and 5, `experience` required, `tags` ≥ 1 (error) with a
+  non-blocking `warn()` advisory when more than 5 tags are added.
+- `onTouched` fired on blur so ngx-vest-forms marks the field touched and
+  shows errors on the standard on-blur timing.
+- Full keyboard accessibility: `radiogroup`/`radio` roles, Arrow/Home/End
+  navigation, roving `tabindex`, and `focus-visible` rings.
+- Packaged form state read via `createFormFeedbackSignals`; a form contract
+  supplied through `provideFormContract`.
+
+## Public API used
+
+`NgxVestForms`, `FormDirective`, `provideFormContract`,
+`createFormFeedbackSignals`, `NgxDeepPartial`, `NgxDeepRequired`,
+`NgxVestSuite`. The CVA primitives (`ControlValueAccessor`,
+`NG_VALUE_ACCESSOR`) come from `@angular/forms`, as expected for any custom
+control.
+
+## Key files
+
+| File | Responsibility |
+| --- | --- |
+| `custom-controls.page.ts` / `.html` | Self-contained page + form |
+| `star-rating.component.ts` | Custom number CVA control |
+| `segmented-control.component.ts` | Custom single-select CVA control |
+| `tag-input.component.ts` | Custom `string[]` CVA control |
+| `custom-controls.validations.ts` | Vest suite (testable in isolation) |
+| `../../models/custom-controls.model.ts` | Model + contract |
+| `custom-controls.content.ts` | "What this demonstrates / learn" cards |
+
+## Behavior
+
+Submitting while invalid keeps the success panel hidden and surfaces field
+errors on the touched controls. A valid submission shows a success panel
+echoing the rating, experience and tag count. Reset clears the form and the
+panel. Adding a sixth tag triggers an advisory warning that never blocks
+submission.

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.content.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.content.ts
@@ -1,0 +1,40 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const customControlsContent = defineExampleContent({
+  demonstrates: {
+    icon: '🎛️',
+    title: 'What this demonstrates',
+    points: [
+      'Three non-native controls built on ControlValueAccessor: a star rating, a segmented selector, and an inline tag editor',
+      'Each control registered via NG_VALUE_ACCESSOR (useExisting, multi:true) and bound with plain [ngModel]',
+      'A custom control participates in a Vest suite — required, range, min-count errors and a non-blocking warning',
+      'onTouched fired on blur so ngx-vest-forms tracks touched state and shows errors on time',
+      'Full keyboard accessibility: radiogroup/radio roles, arrow/Home/End navigation, focus-visible styling',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'The CVA contract',
+        points: [
+          'Why writeValue/registerOnChange/registerOnTouched/setDisabledState is all ngx-vest-forms needs',
+          'How NG_VALUE_ACCESSOR makes a custom widget indistinguishable from a native input to the form directive',
+          'That the Vest suite never knows the value came from a non-native control — it stays a plain spec',
+        ],
+      },
+      {
+        title: 'Touched + accessibility',
+        points: [
+          'How onTouched → ngx-vest-forms blur tracking drives on-blur error display',
+          'Wrapping custom controls in ngx-control-wrapper to render errors and warnings',
+          'Building keyboard-operable, ARIA-correct widgets that still feel like the rest of the app',
+        ],
+      },
+    ],
+    nextStep: {
+      label: 'Next: Submission patterns',
+      route: 'submission-patterns',
+    },
+  },
+});

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.form.html
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.form.html
@@ -1,0 +1,40 @@
+<form
+  ngxVestForm
+  #vestForm="ngxVestForm"
+  [suite]="suite()"
+  [formValue]="formValue()"
+  (formValueChange)="formValueChange.emit($event)"
+  (ngSubmit)="onSubmit()"
+  class="space-y-6"
+>
+  <ngx-control-wrapper class="form-field">
+    <div role="group" aria-label="Rating">
+      <span class="label-text">Rating</span>
+      <ngx-star-rating name="rating" [ngModel]="formValue().rating" />
+    </div>
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <div role="group" aria-label="Experience level">
+      <span class="label-text">Experience level</span>
+      <ngx-segmented-control
+        name="experience"
+        [ngModel]="formValue().experience"
+      />
+    </div>
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <div role="group" aria-label="Tags">
+      <span class="label-text">Tags</span>
+      <ngx-tag-input name="tags" [ngModel]="formValue().tags" />
+    </div>
+  </ngx-control-wrapper>
+
+  <div class="flex justify-end gap-3 pt-2">
+    <button type="button" class="btn btn-secondary" (click)="onReset()">
+      Reset
+    </button>
+    <button type="submit" class="btn btn-primary">Submit</button>
+  </div>
+</form>

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.form.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.form.ts
@@ -1,0 +1,63 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxVestForms,
+  NgxVestSuite,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  CustomControlsModel,
+  customControlsContract,
+} from '../../models/custom-controls.model';
+import { SegmentedControlComponent } from './segmented-control.component';
+import { StarRatingComponent } from './star-rating.component';
+import { TagInputComponent } from './tag-input.component';
+
+@Component({
+  selector: 'ngx-custom-controls-form-body',
+  imports: [
+    NgxVestForms,
+    StarRatingComponent,
+    SegmentedControlComponent,
+    TagInputComponent,
+  ],
+  templateUrl: './custom-controls.form.html',
+  providers: [provideFormContract(customControlsContract)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CustomControlsFormBody {
+  readonly formValue = input.required<CustomControlsModel>();
+  readonly suite = input.required<NgxVestSuite<CustomControlsModel>>();
+
+  readonly formValueChange = output<CustomControlsModel>();
+  readonly submitted = output();
+  readonly resetRequested = output();
+
+  private readonly vestForm =
+    viewChild<FormDirective<CustomControlsModel>>('vestForm');
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+        
+  protected onSubmit(): void {
+    this.submitted.emit();
+  }
+
+  protected onReset(): void {
+    this.resetRequested.emit();
+  }
+
+  resetFormState(value: CustomControlsModel): void {
+    this.vestForm()?.resetForm(value);
+  }
+
+  focusFirstInvalidControl(): void {
+    this.vestForm()?.focusFirstInvalidControl();
+  }
+}

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.html
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.html
@@ -1,0 +1,98 @@
+<div class="page-container">
+  <ngx-page-title
+    title="Custom Controls (ControlValueAccessor)"
+    subtitle="A non-native control participating in validation, warnings, touched state, and submission."
+  />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
+  <ngx-form-page-layout>
+    <div layout-aside class="sidebar-card-stack">
+      <ngx-card title="Why this works">
+        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-200">
+          <li>
+            Each control is a <code>ControlValueAccessor</code> registered via
+            <code>NG_VALUE_ACCESSOR</code>.
+          </li>
+          <li>
+            <code>[ngModel]</code> binds them — ngx-vest-forms can't tell
+            they're not native inputs.
+          </li>
+          <li>
+            <code>onTouched</code> fires on blur, so errors appear on blur just
+            like native fields.
+          </li>
+          <li>
+            The Vest suite is a plain spec — it never knows the control is
+            custom.
+          </li>
+        </ul>
+      </ngx-card>
+
+      <ngx-form-state-card
+        [formState]="formState()"
+        [warnings]="warnings()"
+        [validatedFields]="validatedFields()"
+        [pending]="pending()"
+      />
+    </div>
+
+    <div layout-main>
+      @if (submittedValue(); as submitted) {
+        <ngx-alert-panel tone="success" title="Submitted">
+          <p>
+            Rated <strong>{{ submitted.rating }}/5</strong> as a
+            <strong>{{ submitted.experience }}</strong> developer with
+            {{ submitted.tags?.length ?? 0 }} tag(s).
+          </p>
+        </ngx-alert-panel>
+      }
+
+      <ngx-card
+        title="Custom controls"
+        subtitle="Rating, experience and tags are all non-native controls. Try submitting empty to see validation."
+      >
+        <form
+          ngxVestForm
+          #vestForm="ngxVestForm"
+          [suite]="suite"
+          [formValue]="formValue()"
+          (formValueChange)="formValue.set($event)"
+          (ngSubmit)="onSubmit()"
+          class="space-y-6"
+        >
+          <ngx-control-wrapper class="form-field">
+            <div role="group" aria-label="Rating">
+              <span class="label-text">Rating</span>
+              <ngx-star-rating name="rating" [ngModel]="formValue().rating" />
+            </div>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <div role="group" aria-label="Experience level">
+              <span class="label-text">Experience level</span>
+              <ngx-segmented-control
+                name="experience"
+                [ngModel]="formValue().experience"
+              />
+            </div>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <div role="group" aria-label="Tags">
+              <span class="label-text">Tags</span>
+              <ngx-tag-input name="tags" [ngModel]="formValue().tags" />
+            </div>
+          </ngx-control-wrapper>
+
+          <div class="flex justify-end gap-3 pt-2">
+            <button type="button" class="btn btn-secondary" (click)="reset()">
+              Reset
+            </button>
+            <button type="submit" class="btn btn-primary">Submit</button>
+          </div>
+        </form>
+      </ngx-card>
+    </div>
+  </ngx-form-page-layout>
+</div>

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.html
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.html
@@ -29,12 +29,7 @@
         </ul>
       </ngx-card>
 
-      <ngx-form-state-card
-        [formState]="formState()"
-        [warnings]="warnings()"
-        [validatedFields]="validatedFields()"
-        [pending]="pending()"
-      />
+      <ngx-form-state-card [feedback]="feedback()" />
     </div>
 
     <div layout-main>
@@ -52,46 +47,13 @@
         title="Custom controls"
         subtitle="Rating, experience and tags are all non-native controls. Try submitting empty to see validation."
       >
-        <form
-          ngxVestForm
-          #vestForm="ngxVestForm"
-          [suite]="suite"
+        <ngx-custom-controls-form-body
           [formValue]="formValue()"
+          [suite]="suite"
           (formValueChange)="formValue.set($event)"
-          (ngSubmit)="onSubmit()"
-          class="space-y-6"
-        >
-          <ngx-control-wrapper class="form-field">
-            <div role="group" aria-label="Rating">
-              <span class="label-text">Rating</span>
-              <ngx-star-rating name="rating" [ngModel]="formValue().rating" />
-            </div>
-          </ngx-control-wrapper>
-
-          <ngx-control-wrapper class="form-field">
-            <div role="group" aria-label="Experience level">
-              <span class="label-text">Experience level</span>
-              <ngx-segmented-control
-                name="experience"
-                [ngModel]="formValue().experience"
-              />
-            </div>
-          </ngx-control-wrapper>
-
-          <ngx-control-wrapper class="form-field">
-            <div role="group" aria-label="Tags">
-              <span class="label-text">Tags</span>
-              <ngx-tag-input name="tags" [ngModel]="formValue().tags" />
-            </div>
-          </ngx-control-wrapper>
-
-          <div class="flex justify-end gap-3 pt-2">
-            <button type="button" class="btn btn-secondary" (click)="reset()">
-              Reset
-            </button>
-            <button type="submit" class="btn btn-primary">Submit</button>
-          </div>
-        </form>
+          (submitted)="onSubmit()"
+          (resetRequested)="reset()"
+        />
       </ngx-card>
     </div>
   </ngx-form-page-layout>

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.ts
@@ -1,18 +1,15 @@
 import {
   ChangeDetectionStrategy,
+  computed,
   Component,
   signal,
   viewChild,
 } from '@angular/core';
 import {
-  createFormFeedbackSignals,
-  FormDirective,
-  NgxVestForms,
-  provideFormContract,
+  createEmptyFormState,
 } from 'ngx-vest-forms';
 import {
   CustomControlsModel,
-  customControlsContract,
 } from '../../models/custom-controls.model';
 import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
 import { Card } from '../../ui/card/card.component';
@@ -21,33 +18,27 @@ import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.compo
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
 import { customControlsContent } from './custom-controls.content';
+import { CustomControlsFormBody } from './custom-controls.form';
 import { customControlsSuite } from './custom-controls.validations';
-import { SegmentedControlComponent } from './segmented-control.component';
-import { StarRatingComponent } from './star-rating.component';
-import { TagInputComponent } from './tag-input.component';
 
 /**
  * Custom Controls demo — proves a non-native `ControlValueAccessor` control
- * is indistinguishable from a native input to ngx-vest-forms. Self-contained
- * like the starter page: one `ngxVestForm`, a plain Vest suite, a form
- * contract, and the standard control-wrapper markup. Public API only.
+ * is indistinguishable from a native input to ngx-vest-forms. The page keeps
+ * state and outcomes while the concrete form wiring lives in
+ * `custom-controls.form.html`. Public API only.
  */
 @Component({
   selector: 'ngx-custom-controls-page',
   imports: [
-    NgxVestForms,
     PageTitle,
     Card,
     AlertPanel,
     FormPageLayout,
     FormStateCardComponent,
     ExampleCardsComponent,
-    StarRatingComponent,
-    SegmentedControlComponent,
-    TagInputComponent,
+    CustomControlsFormBody,
   ],
   templateUrl: './custom-controls.page.html',
-  providers: [provideFormContract(customControlsContract)],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CustomControlsPageComponent {
@@ -58,18 +49,14 @@ export class CustomControlsPageComponent {
   protected readonly formValue = signal<CustomControlsModel>({});
   protected readonly submittedValue = signal<CustomControlsModel | null>(null);
 
-  private readonly vestForm =
-    viewChild<FormDirective<CustomControlsModel>>('vestForm');
-  private readonly feedback = createFormFeedbackSignals(this.vestForm);
+  private readonly formBody = viewChild(CustomControlsFormBody);
 
-  protected readonly formState = this.feedback.formState;
-  protected readonly warnings = this.feedback.warnings;
-  protected readonly validatedFields = this.feedback.validatedFields;
-  protected readonly pending = this.feedback.pending;
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
 
   protected onSubmit(): void {
-    if (!this.formState()?.valid) {
+    if (!this.feedback()?.formState()?.valid) {
       this.submittedValue.set(null);
+      this.formBody()?.focusFirstInvalidControl();
       return;
     }
     this.submittedValue.set(structuredClone(this.formValue()));
@@ -77,7 +64,7 @@ export class CustomControlsPageComponent {
 
   protected reset(): void {
     this.submittedValue.set(null);
-    this.vestForm()?.resetForm({});
+    this.formBody()?.resetFormState({});
     this.formValue.set({});
   }
 }

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.ts
@@ -1,0 +1,83 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxVestForms,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  CustomControlsModel,
+  customControlsContract,
+} from '../../models/custom-controls.model';
+import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
+import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
+import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
+import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { PageTitle } from '../../ui/page-title/page-title.component';
+import { customControlsContent } from './custom-controls.content';
+import { customControlsSuite } from './custom-controls.validations';
+import { SegmentedControlComponent } from './segmented-control.component';
+import { StarRatingComponent } from './star-rating.component';
+import { TagInputComponent } from './tag-input.component';
+
+/**
+ * Custom Controls demo — proves a non-native `ControlValueAccessor` control
+ * is indistinguishable from a native input to ngx-vest-forms. Self-contained
+ * like the starter page: one `ngxVestForm`, a plain Vest suite, a form
+ * contract, and the standard control-wrapper markup. Public API only.
+ */
+@Component({
+  selector: 'ngx-custom-controls-page',
+  imports: [
+    NgxVestForms,
+    PageTitle,
+    Card,
+    AlertPanel,
+    FormPageLayout,
+    FormStateCardComponent,
+    ExampleCardsComponent,
+    StarRatingComponent,
+    SegmentedControlComponent,
+    TagInputComponent,
+  ],
+  templateUrl: './custom-controls.page.html',
+  providers: [provideFormContract(customControlsContract)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CustomControlsPageComponent {
+  protected readonly exampleContent = customControlsContent;
+  protected readonly suite = customControlsSuite;
+
+  /** The form value is the single source of truth, owned by the page. */
+  protected readonly formValue = signal<CustomControlsModel>({});
+  protected readonly submittedValue = signal<CustomControlsModel | null>(null);
+
+  private readonly vestForm =
+    viewChild<FormDirective<CustomControlsModel>>('vestForm');
+  private readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+  protected readonly formState = this.feedback.formState;
+  protected readonly warnings = this.feedback.warnings;
+  protected readonly validatedFields = this.feedback.validatedFields;
+  protected readonly pending = this.feedback.pending;
+
+  protected onSubmit(): void {
+    if (!this.formState()?.valid) {
+      this.submittedValue.set(null);
+      return;
+    }
+    this.submittedValue.set(structuredClone(this.formValue()));
+  }
+
+  protected reset(): void {
+    this.submittedValue.set(null);
+    this.vestForm()?.resetForm({});
+    this.formValue.set({});
+  }
+}

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.validations.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.validations.ts
@@ -1,0 +1,40 @@
+import { type NgxVestSuite } from 'ngx-vest-forms';
+import { create, enforce, omitWhen, test, warn } from 'vest';
+import { CustomControlsModel } from '../../models/custom-controls.model';
+
+/**
+ * Vest suite for the Custom Controls demo.
+ *
+ * The suite is a plain Vest spec with no Angular dependency — the values it
+ * validates happen to come from `ControlValueAccessor` controls, but the suite
+ * neither knows nor cares. Unit-test it directly: `customControlsSuite(model)`.
+ */
+export const customControlsSuite: NgxVestSuite<CustomControlsModel> = create(
+  (model: CustomControlsModel) => {
+    test('rating', 'Pick a rating', () => {
+      enforce(model.rating != null && model.rating >= 1).isTruthy();
+    });
+
+    omitWhen(!model.rating, () => {
+      test('rating', 'Rating must be between 1 and 5', () => {
+        enforce(model.rating ?? 0).isBetween(1, 5);
+      });
+    });
+
+    test('experience', 'Select your experience level', () => {
+      enforce(model.experience).isNotBlank();
+    });
+
+    test('tags', 'Add at least one tag', () => {
+      enforce(model.tags ?? []).longerThanOrEquals(1);
+    });
+
+    // Advisory, non-blocking guidance: lots of tags still submits fine.
+    omitWhen((model.tags ?? []).length === 0, () => {
+      test('tags', 'Five tags is plenty — consider trimming the list', () => {
+        warn();
+        enforce(model.tags ?? []).shorterThanOrEquals(5);
+      });
+    });
+  }
+);

--- a/apps/examples/src/app/pages/custom-controls-form/segmented-control.component.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/segmented-control.component.ts
@@ -125,7 +125,13 @@ export class SegmentedControlComponent implements ControlValueAccessor {
     event.preventDefault();
     const next = this.segments[nextIndex]?.value;
     if (next === undefined) return;
-    this.select(next);
+    // Boundary keys resolve to the current segment — only emit on real change.
+    if (next !== this.value()) {
+      this.select(next);
+    }
+    // Direct id lookup keeps the demo dependency-free; this app is CSR-only so
+    // `document` access is safe (a viewChildren()-based query would be the
+    // SSR-safe alternative).
     document.getElementById(`${this.groupId}-${next}`)?.focus();
   }
 

--- a/apps/examples/src/app/pages/custom-controls-form/segmented-control.component.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/segmented-control.component.ts
@@ -1,0 +1,148 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  signal,
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+type Segment = {
+  readonly value: string;
+  readonly label: string;
+}
+
+let nextId = 0;
+
+/**
+ * A segmented single-select control built on {@link ControlValueAccessor}.
+ * Registered through `NG_VALUE_ACCESSOR`, so `[ngModel]` and ngx-vest-forms
+ * treat it like a native radio group: validation, touched state and
+ * submission all work unchanged.
+ *
+ * Accessibility: `radiogroup`/`radio` semantics, Arrow/Home/End keyboard
+ * navigation, `focus-visible` rings, and `onTouched` fired on blur.
+ */
+@Component({
+  selector: 'ngx-segmented-control',
+  template: `
+    <div
+      role="radiogroup"
+      aria-label="Experience level"
+      class="inline-flex rounded-lg border border-gray-300 bg-gray-50 p-1
+             dark:border-gray-600 dark:bg-gray-800"
+      (focusout)="onBlur()"
+    >
+      @for (segment of segments; track segment.value) {
+        <button
+          type="button"
+          role="radio"
+          [id]="groupId + '-' + segment.value"
+          [attr.aria-checked]="value() === segment.value"
+          [attr.tabindex]="rovingIndex(segment.value)"
+          [disabled]="disabled()"
+          (click)="select(segment.value)"
+          (keydown)="onKeydown($event, segment.value)"
+          class="rounded-md px-4 py-1.5 text-sm font-medium transition-colors
+                 focus:outline-none focus-visible:ring-2
+                 focus-visible:ring-primary-500
+                 disabled:cursor-not-allowed disabled:opacity-50"
+          [class.bg-primary-600]="value() === segment.value"
+          [class.text-white]="value() === segment.value"
+          [class.text-gray-600]="value() !== segment.value"
+          [class.dark:text-gray-300]="value() !== segment.value"
+          [class.hover:bg-gray-200]="
+            value() !== segment.value && !disabled()
+          "
+          [class.dark:hover:bg-gray-700]="
+            value() !== segment.value && !disabled()
+          "
+        >
+          {{ segment.label }}
+        </button>
+      }
+    </div>
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => SegmentedControlComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class SegmentedControlComponent implements ControlValueAccessor {
+  protected readonly groupId = `ngx-segmented-${nextId++}`;
+  protected readonly segments: readonly Segment[] = [
+    { value: 'junior', label: 'Junior' },
+    { value: 'mid', label: 'Mid' },
+    { value: 'senior', label: 'Senior' },
+  ];
+
+  protected readonly value = signal<string | null>(null);
+  protected readonly disabled = signal(false);
+
+  private onChange: (value: string | null) => void = () => undefined;
+  private onTouched: () => void = () => undefined;
+
+  protected rovingIndex(segmentValue: string): number {
+    const current = this.value() ?? this.segments[0]?.value;
+    return segmentValue === current ? 0 : -1;
+  }
+
+  protected select(segmentValue: string): void {
+    if (this.disabled()) return;
+    this.value.set(segmentValue);
+    this.onChange(segmentValue);
+  }
+
+  protected onBlur(): void {
+    this.onTouched();
+  }
+
+  protected onKeydown(event: KeyboardEvent, segmentValue: string): void {
+    if (this.disabled()) return;
+    const index = this.segments.findIndex((s) => s.value === segmentValue);
+    let nextIndex: number | null = null;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = Math.min(this.segments.length - 1, index + 1);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex = Math.max(0, index - 1);
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = this.segments.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    const next = this.segments[nextIndex]?.value;
+    if (next === undefined) return;
+    this.select(next);
+    document.getElementById(`${this.groupId}-${next}`)?.focus();
+  }
+
+  // ── ControlValueAccessor ──────────────────────────────────────────
+  writeValue(value: string | null): void {
+    this.value.set(typeof value === 'string' ? value : null);
+  }
+
+  registerOnChange(fn: (value: string | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled.set(isDisabled);
+  }
+}

--- a/apps/examples/src/app/pages/custom-controls-form/star-rating.component.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/star-rating.component.ts
@@ -1,0 +1,141 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  signal,
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+let nextId = 0;
+
+/**
+ * A non-native star-rating control built on Angular's
+ * {@link ControlValueAccessor}. Registered through `NG_VALUE_ACCESSOR` so it
+ * plugs into `[ngModel]` and ngx-vest-forms exactly like a native `<input>`:
+ * it participates in validation, touched tracking and submission.
+ *
+ * Accessibility: rendered as a `radiogroup` of `radio` buttons, fully keyboard
+ * operable (Arrow/Home/End), with `focus-visible` styling. `onTouched` fires on
+ * blur so ngx-vest-forms marks the field touched and shows errors on time.
+ */
+@Component({
+  selector: 'ngx-star-rating',
+  template: `
+    <div
+      role="radiogroup"
+      [attr.aria-label]="'Rating, 1 to 5 stars'"
+      class="flex items-center gap-1"
+      (focusout)="onBlur()"
+    >
+      @for (star of stars; track star) {
+        <button
+          type="button"
+          role="radio"
+          [id]="groupId + '-' + star"
+          [attr.aria-label]="star + (star === 1 ? ' star' : ' stars')"
+          [attr.aria-checked]="value() === star"
+          [attr.tabindex]="rovingIndex(star)"
+          [disabled]="disabled()"
+          (click)="select(star)"
+          (keydown)="onKeydown($event, star)"
+          class="rounded p-1 text-2xl leading-none transition-colors
+                 focus:outline-none focus-visible:ring-2
+                 focus-visible:ring-primary-500
+                 disabled:cursor-not-allowed disabled:opacity-50"
+          [class.text-primary-500]="star <= (hovered() ?? value() ?? 0)"
+          [class.text-gray-300]="star > (hovered() ?? value() ?? 0)"
+          [class.dark:text-gray-600]="star > (hovered() ?? value() ?? 0)"
+          (mouseenter)="!disabled() && hovered.set(star)"
+          (mouseleave)="hovered.set(null)"
+        >
+          <span aria-hidden="true">{{
+            star <= (hovered() ?? value() ?? 0) ? '★' : '☆'
+          }}</span>
+        </button>
+      }
+
+      <span class="ml-2 text-sm text-gray-500 dark:text-gray-400">
+        {{ value() ? value() + ' / 5' : 'No rating' }}
+      </span>
+    </div>
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => StarRatingComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class StarRatingComponent implements ControlValueAccessor {
+  protected readonly groupId = `ngx-star-rating-${nextId++}`;
+  protected readonly stars = [1, 2, 3, 4, 5] as const;
+
+  protected readonly value = signal<number | null>(null);
+  protected readonly hovered = signal<number | null>(null);
+  protected readonly disabled = signal(false);
+
+  private onChange: (value: number | null) => void = () => undefined;
+  private onTouched: () => void = () => undefined;
+
+  /** Active descendant gets tabindex 0, the rest -1 (roving tabindex). */
+  protected rovingIndex(star: number): number {
+    const current = this.value() ?? 1;
+    return star === current ? 0 : -1;
+  }
+
+  protected select(star: number): void {
+    if (this.disabled()) return;
+    this.value.set(star);
+    this.onChange(star);
+  }
+
+  protected onBlur(): void {
+    this.onTouched();
+  }
+
+  protected onKeydown(event: KeyboardEvent, star: number): void {
+    if (this.disabled()) return;
+    let next: number | null = null;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        next = Math.min(5, star + 1);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        next = Math.max(1, star - 1);
+        break;
+      case 'Home':
+        next = 1;
+        break;
+      case 'End':
+        next = 5;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    this.select(next);
+    const el = document.getElementById(`${this.groupId}-${next}`);
+    el?.focus();
+  }
+
+  // ── ControlValueAccessor ──────────────────────────────────────────
+  writeValue(value: number | null): void {
+    this.value.set(typeof value === 'number' ? value : null);
+  }
+
+  registerOnChange(fn: (value: number | null) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled.set(isDisabled);
+  }
+}

--- a/apps/examples/src/app/pages/custom-controls-form/star-rating.component.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/star-rating.component.ts
@@ -117,7 +117,15 @@ export class StarRatingComponent implements ControlValueAccessor {
         return;
     }
     event.preventDefault();
-    this.select(next);
+    // Boundary keys (e.g. ArrowLeft on the first star) resolve to the current
+    // value — only emit when it actually changes so we don't mark the control
+    // dirty on a no-op.
+    if (next !== star) {
+      this.select(next);
+    }
+    // Direct id lookup keeps the demo dependency-free; this app is CSR-only so
+    // `document` access is safe (a viewChildren()-based query would be the
+    // SSR-safe alternative).
     const el = document.getElementById(`${this.groupId}-${next}`);
     el?.focus();
   }

--- a/apps/examples/src/app/pages/custom-controls-form/tag-input.component.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/tag-input.component.ts
@@ -1,0 +1,124 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  forwardRef,
+  signal,
+} from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+let nextId = 0;
+
+/**
+ * An inline tag editor built on {@link ControlValueAccessor}. Type and press
+ * Enter to add a tag; click a tag (or press its ×) to remove it. The model
+ * value is a `string[]`, fed through `[ngModel]` so ngx-vest-forms validates
+ * it (≥1 tag required, >5 advisory warning) like any native field.
+ *
+ * Accessibility: a labelled text input plus a `list` of tags, each removable
+ * via a real `button` with an accessible name. `onTouched` fires when focus
+ * leaves the control so the field is marked touched.
+ */
+@Component({
+  selector: 'ngx-tag-input',
+  template: `
+    <div (focusout)="onFocusOut($event)">
+      @if (tags().length > 0) {
+        <ul class="mb-2 flex flex-wrap gap-2" role="list">
+          @for (tag of tags(); track tag; let i = $index) {
+            <li
+              class="inline-flex items-center gap-1 rounded-full
+                     bg-primary-100 px-3 py-1 text-sm text-primary-800
+                     dark:bg-primary-900/40 dark:text-primary-200"
+            >
+              <span>{{ tag }}</span>
+              <button
+                type="button"
+                [attr.aria-label]="'Remove tag ' + tag"
+                [disabled]="disabled()"
+                (click)="remove(i)"
+                class="rounded-full leading-none text-primary-600
+                       hover:text-primary-900 focus:outline-none
+                       focus-visible:ring-2 focus-visible:ring-primary-500
+                       disabled:cursor-not-allowed disabled:opacity-50
+                       dark:text-primary-300"
+              >
+                <span aria-hidden="true">×</span>
+              </button>
+            </li>
+          }
+        </ul>
+      }
+
+      <input
+        #tagBox
+        type="text"
+        class="input-field"
+        [id]="inputId"
+        [disabled]="disabled()"
+        aria-label="Add a tag"
+        placeholder="Type a tag and press Enter"
+        (keydown.enter)="add($event, tagBox)"
+      />
+    </div>
+  `,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => TagInputComponent),
+      multi: true,
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class TagInputComponent implements ControlValueAccessor {
+  protected readonly inputId = `ngx-tag-input-${nextId++}`;
+  protected readonly tags = signal<string[]>([]);
+  protected readonly disabled = signal(false);
+
+  private onChange: (value: string[]) => void = () => undefined;
+  private onTouched: () => void = () => undefined;
+
+  protected add(event: Event, box: HTMLInputElement): void {
+    event.preventDefault();
+    if (this.disabled()) return;
+    const raw = box.value.trim();
+    if (!raw) return;
+    if (this.tags().includes(raw)) {
+      box.value = '';
+      return;
+    }
+    this.tags.update((tags) => [...tags, raw]);
+    box.value = '';
+    this.onChange(this.tags());
+  }
+
+  protected remove(index: number): void {
+    if (this.disabled()) return;
+    this.tags.update((tags) => tags.filter((_, i) => i !== index));
+    this.onChange(this.tags());
+  }
+
+  protected onFocusOut(event: FocusEvent): void {
+    const next = event.relatedTarget as Node | null;
+    if (!next || !(event.currentTarget as Node).contains(next)) {
+      this.onTouched();
+    }
+  }
+
+  // ── ControlValueAccessor ──────────────────────────────────────────
+  writeValue(value: string[] | null): void {
+    this.tags.set(Array.isArray(value) ? [...value] : []);
+  }
+
+  registerOnChange(fn: (value: string[]) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.disabled.set(isDisabled);
+  }
+}

--- a/apps/examples/src/app/pages/date-range-adapter/README.md
+++ b/apps/examples/src/app/pages/date-range-adapter/README.md
@@ -1,0 +1,58 @@
+# Composite Adapter Recipe
+
+Route: `date-range-adapter` · Title: "Composite Adapter Recipe"
+
+## What & why
+
+This page shows how to map **one composite UI control to multiple form fields**
+with split-field validation. A travel form needs a departure date and a return
+date that cross-validate each other. The page offers two switchable approaches:
+
+1. **Split Wrappers** — each date is its own `[ngModel]` inside a separate
+   `<ngx-control-wrapper>`. The library handles ARIA wiring, display modes,
+   pending state, and warnings automatically. The trade-off is two visually
+   separate controls instead of a unified date-range widget.
+2. **Composite Adapter** — a single `ngx-date-range-adapter` widget drives
+   hidden proxy `[ngModel]` fields. The adapter must reproduce the library's
+   display-mode gating and ARIA wiring itself, because `<ngx-control-wrapper>`
+   discovers exactly one `NgModel` child and cannot bind a one-widget /
+   many-fields control.
+
+Either way, `validationConfig` keeps the two dates cross-validated.
+
+## ngx-vest-forms public APIs showcased
+
+- `createValidationConfig<TravelFormModel>().bidirectional('departureDate',
+  'returnDate').build()` — bidirectional cross-field revalidation.
+- `setValueAtPath` — fan the composite adapter value out to flat model paths.
+- `provideFormContract(travelFormContract)` — shape contract for the form body.
+- `ControlWrapperComponent` / `NgxVestForms` — wrapper-based field approach and
+  template directives.
+- `FormDirective<TravelFormModel>` — `triggerFormValidation()`, `resetForm()`,
+  `formState()`, `fieldWarnings()`, `touchedFieldPaths()`.
+- `fieldWarningsToRecord` / `createEmptyFormState` — feedback helpers for the
+  sidebar state card.
+
+## Key files
+
+- `travel.validations.ts` — Vest suite with `omitWhen` ordering rule and a
+  `warn()` advance-notice suggestion.
+- `date-range-adapter.component.ts` — the composite adapter: value fan-in,
+  manual on-blur-or-submit gating, error/warning aggregation, ARIA regions.
+- `travel.form.ts` / `.form.html` — form body switching approaches; performs
+  fan-out via `setValueAtPath` and defers `triggerFormValidation()` until proxy
+  inputs sync.
+- `travel.page.ts` / `.page.html` — page shell, approach selector, sidebar, and
+  form state card.
+- `travel.content.ts` — typed `ExampleContent` rendered by
+  `<ngx-example-cards>`.
+
+## Behavior
+
+The adapter emits `{ departureDate, returnDate }`; the form body clones the
+model, writes both paths with `setValueAtPath`, emits the new model, then waits
+for the hidden proxy `[ngModel]`s to render (`afterNextRender` + a macrotask)
+before calling `triggerFormValidation()`. The Vest suite requires both dates,
+enforces return-after-departure inside `omitWhen`, and adds a non-blocking
+`warn()` suggesting at least three days between dates. Switching approaches
+resets the form and the adapter's touched state.

--- a/apps/examples/src/app/pages/date-range-adapter/travel.content.ts
+++ b/apps/examples/src/app/pages/date-range-adapter/travel.content.ts
@@ -1,0 +1,44 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const travelContent = defineExampleContent({
+  demonstrates: {
+    icon: '🗓️',
+    title: 'What this demonstrates',
+    points: [
+      'Mapping one composite date-range UI control to two flat model fields (departureDate + returnDate) with split-field validation',
+      'Two switchable approaches: independent <ngx-control-wrapper> fields vs. a single composite adapter component',
+      'Composite adapter fan-out using setValueAtPath to write the widget value back to separate model fields',
+      'Hidden proxy [ngModel] fields registering departureDate and returnDate in the form tree for the adapter approach',
+      'Bidirectional cross-field validation via createValidationConfig().bidirectional(departureDate, returnDate) so changing one date revalidates the other',
+      'Manual on-blur-or-submit display gating and error/warning aggregation inside the adapter, since one wrapper cannot bind to multiple NgModels',
+      'A non-blocking Vest warn() suggesting at least 3 days between dates, alongside blocking date-order errors',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Composite control adapters',
+        points: [
+          'Why <ngx-control-wrapper> binds to a single NgModel, so a one-widget/many-fields control needs a custom adapter',
+          'Fan a composite value out to flat model paths with setValueAtPath and re-emit the model',
+          'Trigger validation after the hidden proxy [ngModel]s sync using afterNextRender + triggerFormValidation',
+        ],
+      },
+      {
+        title: 'Split-field cross validation',
+        points: [
+          'Wire interdependent fields with createValidationConfig().bidirectional() so each date change re-runs the other',
+          'Use omitWhen + warn() in the Vest suite for conditional ordering errors and soft advance-notice warnings',
+        ],
+      },
+      {
+        title: 'Accessible custom widgets',
+        points: [
+          'Reproduce the library’s on-blur-or-submit display mode and aria-describedby wiring by hand when no wrapper applies',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Complex nested form', route: 'complex-nested' },
+  },
+});

--- a/apps/examples/src/app/pages/date-range-adapter/travel.form.ts
+++ b/apps/examples/src/app/pages/date-range-adapter/travel.form.ts
@@ -14,6 +14,7 @@ import {
 import {
   ControlWrapperComponent,
   createEmptyFormState,
+  createFormFeedbackSignals,
   fieldWarningsToRecord,
   FormDirective,
   NgxValidationConfig,
@@ -80,27 +81,7 @@ export class TravelFormBody {
     });
   }
 
-  /** Exposes the directive's packaged form state with up-to-date errors. */
-  readonly formState = computed(() => {
-    const state = this.vestForm()?.formState();
-    if (!state) return createEmptyFormState<TravelFormModel>();
-    return state;
-  });
-
-  /** Exposes field warnings as a plain Record for presentational components. */
-  readonly warnings = computed(() =>
-    fieldWarningsToRecord(this.vestForm()?.fieldWarnings() ?? new Map())
-  );
-
-  /** Field paths that have been validated (touched/blurred or submitted). */
-  readonly validatedFields = computed(
-    () => this.vestForm()?.touchedFieldPaths() ?? []
-  );
-
-  /** True while async validation is in progress. */
-  readonly pending = computed(
-    () => this.vestForm()?.ngForm.form.pending ?? false
-  );
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
 
   protected onRangeChange(range: DateRangeValue): void {
     const next = structuredClone(this.formValue());

--- a/apps/examples/src/app/pages/date-range-adapter/travel.page.html
+++ b/apps/examples/src/app/pages/date-range-adapter/travel.page.html
@@ -4,6 +4,8 @@
     subtitle="Map one composite UI control to multiple form fields with split-field validation."
   />
 
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
   <fieldset class="mb-6">
     <legend class="mb-2 text-sm font-medium text-gray-700 dark:text-gray-200">
       Form approach

--- a/apps/examples/src/app/pages/date-range-adapter/travel.page.html
+++ b/apps/examples/src/app/pages/date-range-adapter/travel.page.html
@@ -125,13 +125,10 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="formBody.formState()"
+        [feedback]="feedback()"
         [formValue]="formValue()"
         [errors]="formErrors()"
-        [warnings]="formBody.warnings()"
-        [validatedFields]="formBody.validatedFields()"
-        [pending]="formBody.pending()"
-      />
+        />
     </div>
 
     <div layout-main>

--- a/apps/examples/src/app/pages/date-range-adapter/travel.page.ts
+++ b/apps/examples/src/app/pages/date-range-adapter/travel.page.ts
@@ -30,6 +30,7 @@ import { travelValidationSuite } from './travel.validations';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TravelPageComponent {
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
   private readonly initialFormValue: TravelFormModel = {};
 
   protected readonly formValue = signal<TravelFormModel>(this.initialFormValue);
@@ -49,32 +50,32 @@ export class TravelPageComponent {
 
   /** Merged errors from both date fields for the sidebar card. */
   protected readonly formErrors = computed(() => {
-    const errors = this.formBody()?.formState()?.errors ?? {};
-    return [...new Set(Object.values(errors).flat())];
+    const errors = this.feedback()?.formState()?.errors ?? {};
+    return [...new Set(Object.values(errors).flat())] as string[];
   });
 
   protected readonly departureErrors = computed(() => {
-    const errors = this.formBody()?.formState()?.errors ?? {};
+    const errors = this.feedback()?.formState()?.errors ?? {};
     return errors['departureDate'] ?? [];
   });
 
   protected readonly returnErrors = computed(() => {
-    const errors = this.formBody()?.formState()?.errors ?? {};
+    const errors = this.feedback()?.formState()?.errors ?? {};
     return errors['returnDate'] ?? [];
   });
 
   protected readonly departureWarnings = computed(() => {
-    const warnings = this.formBody()?.warnings() ?? {};
+    const warnings = this.feedback()?.warnings() ?? {};
     return warnings['departureDate'] ?? [];
   });
 
   protected readonly returnWarnings = computed(() => {
-    const warnings = this.formBody()?.warnings() ?? {};
+    const warnings = this.feedback()?.warnings() ?? {};
     return warnings['returnDate'] ?? [];
   });
 
   protected save(): void {
-    if (this.formBody()?.formState()?.valid) {
+    if (this.feedback()?.formState()?.valid) {
       // Intentionally quiet in examples
     }
   }

--- a/apps/examples/src/app/pages/date-range-adapter/travel.page.ts
+++ b/apps/examples/src/app/pages/date-range-adapter/travel.page.ts
@@ -10,7 +10,9 @@ import { TravelFormModel } from '../../models/travel-form.model';
 import { Card } from '../../ui/card/card.component';
 import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
+import { travelContent } from './travel.content';
 import { TravelFormApproach, TravelFormBody } from './travel.form';
 import { travelValidationSuite } from './travel.validations';
 
@@ -18,6 +20,7 @@ import { travelValidationSuite } from './travel.validations';
   selector: 'ngx-travel-page',
   imports: [
     Card,
+    ExampleCardsComponent,
     FormPageLayout,
     FormStateCardComponent,
     PageTitle,
@@ -36,6 +39,8 @@ export class TravelPageComponent {
   private readonly formBody = viewChild(TravelFormBody);
 
   protected readonly suite = travelValidationSuite;
+
+  protected readonly exampleContent = travelContent;
 
   protected readonly validationConfig =
     createValidationConfig<TravelFormModel>()

--- a/apps/examples/src/app/pages/display-modes-demo/README.md
+++ b/apps/examples/src/app/pages/display-modes-demo/README.md
@@ -1,0 +1,60 @@
+# Display Modes Demo
+
+Compare error and warning visibility timing across display modes.
+
+## Why this demo exists
+
+When validation feedback appears is a UX decision as important as the rules
+themselves. Showing every error immediately can feel hostile; hiding it until
+submit can feel unhelpful. `ngx-vest-forms` lets you choose the timing per
+field for errors and warnings independently. This demo puts all of those modes
+on a single form so the differences are visible side by side, and shows how a
+parent component can drive an on-submit reveal programmatically.
+
+## What it does
+
+- One form, one model, one Vest suite. Each field is wrapped in
+  `ngx-control-wrapper` with an explicit `errorDisplayMode` or
+  `warningDisplayMode`.
+- Error modes shown: `always` (visible even while pristine), `on-dirty`
+  (after the value changes), and `on-submit` (stays quiet until the form is
+  submitted programmatically).
+- Warning modes shown: `always`, `on-dirty`, and `on-touch` (after blur).
+- The form runs `triggerFormValidation()` on first render, so the contrast
+  between modes is visible immediately without any interaction.
+- An external "Programmatically submit demo form" button simulates a
+  parent-controlled submit: it calls `NgForm.onSubmit()`, then
+  `markAllAsTouched()`, then `triggerFormValidation()` to reveal the
+  `on-submit` field.
+- Errors are blocking (`enforce`); warnings are non-blocking (Vest `warn()`).
+  Both are validated by the same suite but surfaced separately.
+
+## ngx-vest-forms APIs showcased
+
+- `ngx-control-wrapper` with `[errorDisplayMode]` and `[warningDisplayMode]`
+  inputs.
+- `NgxVestForms` directive bundle and the `ngxVestForm` template directive.
+- `FormDirective` methods: `triggerFormValidation()`, `markAllAsTouched()`,
+  and `ngForm.onSubmit()`.
+- `createFormFeedbackSignals()` exposing `formState`, `warnings`,
+  `validatedFields`, and `pending`.
+- Vest `warn()` for non-blocking warnings alongside `enforce()` errors.
+
+## Key files
+
+- `display-modes-demo.page.ts` — thin page wrapper holding the model signal.
+- `display-modes-demo.form.ts` / `.form.html` — the form body, per-field
+  display modes, render-time validation, and programmatic submit.
+- `display-modes-demo.validations.ts` — Vest suite with parallel error and
+  warning tests.
+- `display-modes-demo.content.ts` — in-app "What this demonstrates / learn"
+  cards.
+
+## Behavior notes
+
+- The form deliberately validates on render so a developer can see each mode's
+  timing without touching the inputs.
+- The `on-submit` field only reveals its error through the external
+  programmatic-submit button, mirroring a parent-controlled submit flow.
+- Warnings never block submission; they are tracked and displayed separately
+  from errors.

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.content.ts
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.content.ts
@@ -5,6 +5,7 @@ export const displayModesContent = defineExampleContent({
     icon: '👁️',
     title: 'What this demonstrates',
     points: [
+      'Page-level NGX_ERROR_DISPLAY_MODE_TOKEN and NGX_WARNING_DISPLAY_MODE_TOKEN defaults, then per-field overrides on ngx-control-wrapper.',
       'Per-field errorDisplayMode and warningDisplayMode on ngx-control-wrapper, all bound to one form and model.',
       'Error timing compared side by side: "always" (immediate, even pristine), "on-dirty" (after typing), and "on-submit" (only after programmatic submit).',
       'Warning timing compared: "always", "on-dirty", and "on-touch" (after blur).',
@@ -19,6 +20,7 @@ export const displayModesContent = defineExampleContent({
       {
         title: 'Display mode mechanics',
         points: [
+          'Set default modes for a whole subtree with NGX_ERROR_DISPLAY_MODE_TOKEN and NGX_WARNING_DISPLAY_MODE_TOKEN.',
           'Set errorDisplayMode / warningDisplayMode per field on ngx-control-wrapper.',
           'Choose timing per field: always, on-dirty, on-touch, or on-submit.',
           'Errors and warnings have independent display modes on the same control.',

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.content.ts
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.content.ts
@@ -1,0 +1,45 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const displayModesContent = defineExampleContent({
+  demonstrates: {
+    icon: '👁️',
+    title: 'What this demonstrates',
+    points: [
+      'Per-field errorDisplayMode and warningDisplayMode on ngx-control-wrapper, all bound to one form and model.',
+      'Error timing compared side by side: "always" (immediate, even pristine), "on-dirty" (after typing), and "on-submit" (only after programmatic submit).',
+      'Warning timing compared: "always", "on-dirty", and "on-touch" (after blur).',
+      'The form is validated on first render so every mode\'s difference is visible without interacting.',
+      'A parent-controlled submit path: an external button calls NgForm.onSubmit(), markAllAsTouched(), and triggerFormValidation() to reveal on-submit fields.',
+      'Errors (blocking, via enforce) and warnings (non-blocking, via Vest warn()) tracked separately in the same suite.',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Display mode mechanics',
+        points: [
+          'Set errorDisplayMode / warningDisplayMode per field on ngx-control-wrapper.',
+          'Choose timing per field: always, on-dirty, on-touch, or on-submit.',
+          'Errors and warnings have independent display modes on the same control.',
+        ],
+      },
+      {
+        title: 'Programmatic submission',
+        points: [
+          'Reveal on-submit feedback by calling NgForm.onSubmit() from a parent.',
+          'Pair it with markAllAsTouched() and triggerFormValidation() for full feedback.',
+          'Use triggerFormValidation() on render to show every mode immediately.',
+        ],
+      },
+      {
+        title: 'Reading form feedback',
+        points: [
+          'createFormFeedbackSignals exposes formState, warnings, validatedFields, pending.',
+          'Surface warnings independently of errors since warnings never block submit.',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Business hours', route: 'business-hours' },
+  },
+});

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.form.html
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.form.html
@@ -12,10 +12,46 @@
     class="space-y-8"
   >
     <ngx-card
+      title="Token default: errorDisplayMode='on-submit'"
+      subtitle="This wrapper does not set errorDisplayMode itself — the page-level NGX_ERROR_DISPLAY_MODE_TOKEN provides the default."
+    >
+      <ngx-control-wrapper>
+        <label for="tokenDefaultError" class="label-text"
+          >Username (Token Default Error)</label
+        >
+        <input
+          id="tokenDefaultError"
+          name="tokenDefaultError"
+          [ngModel]="formValue().tokenDefaultError"
+          class="input-field"
+          placeholder="Leave empty, then use the external submit button..."
+        />
+      </ngx-control-wrapper>
+    </ngx-card>
+
+    <ngx-card
+      title="Token default: warningDisplayMode='on-touch'"
+      subtitle="This wrapper relies on the page-level NGX_WARNING_DISPLAY_MODE_TOKEN, then the explicit examples below override it per field."
+    >
+      <ngx-control-wrapper>
+        <label for="tokenDefaultWarning" class="label-text"
+          >Username (Token Default Warning)</label
+        >
+        <input
+          id="tokenDefaultWarning"
+          name="tokenDefaultWarning"
+          [ngModel]="formValue().tokenDefaultWarning"
+          class="input-field"
+          placeholder="Type a short username, then blur..."
+        />
+      </ngx-control-wrapper>
+    </ngx-card>
+
+    <ngx-card
       title="Error Display Mode: 'always'"
       subtitle="Errors appear immediately, even on pristine fields."
     >
-      <ngx-control-wrapper [errorDisplayMode]="'always'">
+      <ngx-control-wrapper errorDisplayMode="always">
         <label for="alwaysError" class="label-text"
           >Username (Always Mode)</label
         >
@@ -33,7 +69,7 @@
       title="Error Display Mode: 'on-dirty'"
       subtitle="Errors appear as soon as you type."
     >
-      <ngx-control-wrapper [errorDisplayMode]="'on-dirty'">
+      <ngx-control-wrapper errorDisplayMode="on-dirty">
         <label for="dirtyError" class="label-text"
           >Username (On-Dirty Mode)</label
         >
@@ -51,7 +87,7 @@
       title="Error Display Mode: 'on-submit'"
       subtitle="This field stays quiet until the parent container submits the form programmatically."
     >
-      <ngx-control-wrapper [errorDisplayMode]="'on-submit'">
+      <ngx-control-wrapper errorDisplayMode="on-submit">
         <label for="submitError" class="label-text"
           >Username (On-Submit Mode)</label
         >
@@ -78,7 +114,7 @@
       title="Warning Display Mode: 'always'"
       subtitle="Warnings appear immediately on pristine fields."
     >
-      <ngx-control-wrapper [warningDisplayMode]="'always'">
+      <ngx-control-wrapper warningDisplayMode="always">
         <label for="alwaysWarning" class="label-text"
           >Username (Always Warning)</label
         >
@@ -96,7 +132,7 @@
       title="Warning Display Mode: 'on-dirty'"
       subtitle="Warnings appear as soon as you type."
     >
-      <ngx-control-wrapper [warningDisplayMode]="'on-dirty'">
+      <ngx-control-wrapper warningDisplayMode="on-dirty">
         <label for="dirtyWarning" class="label-text"
           >Username (On-Dirty Warning)</label
         >
@@ -114,7 +150,7 @@
       title="Warning Display Mode: 'on-touch'"
       subtitle="Warnings appear after blur (traditional behavior)."
     >
-      <ngx-control-wrapper [warningDisplayMode]="'on-touch'">
+      <ngx-control-wrapper warningDisplayMode="on-touch">
         <label for="touchWarning" class="label-text"
           >Username (On-Touch Warning)</label
         >
@@ -137,7 +173,8 @@
       class="text-sm text-gray-600 dark:text-gray-300"
     >
       This mirrors a parent-controlled submit flow where submission is triggered
-      externally/programmatically.
+      externally/programmatically. The token-default submit field above relies
+      entirely on this provider-driven path.
     </p>
     <button
       type="button"

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.form.ts
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.form.ts
@@ -32,14 +32,6 @@ export class DisplayModesDemoFormBody {
     viewChild<FormDirective<DisplayModesDemoModel>>('vestForm');
   readonly feedback = createFormFeedbackSignals(this.vestForm);
 
-  /** Exposes the directive's packaged form state with up-to-date errors. */
-  
-  /** Exposes field warnings as a plain Record for presentational components. */
-  
-  /** Field paths that have been validated (touched/blurred or submitted). */
-  
-  /** True while async validation is in progress. */
-  
   constructor() {
     afterNextRender(() => {
       // This demo intentionally shows display modes against an already-validated

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.form.ts
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.form.ts
@@ -30,20 +30,16 @@ export class DisplayModesDemoFormBody {
 
   private readonly vestForm =
     viewChild<FormDirective<DisplayModesDemoModel>>('vestForm');
-  private readonly formFeedback = createFormFeedbackSignals(this.vestForm);
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
 
   /** Exposes the directive's packaged form state with up-to-date errors. */
-  readonly formState = this.formFeedback.formState;
-
+  
   /** Exposes field warnings as a plain Record for presentational components. */
-  readonly warnings = this.formFeedback.warnings;
-
+  
   /** Field paths that have been validated (touched/blurred or submitted). */
-  readonly validatedFields = this.formFeedback.validatedFields;
-
+  
   /** True while async validation is in progress. */
-  readonly pending = this.formFeedback.pending;
-
+  
   constructor() {
     afterNextRender(() => {
       // This demo intentionally shows display modes against an already-validated

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.page.html
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.page.html
@@ -1,8 +1,10 @@
 <div class="page-container">
   <ngx-page-title
     title="Display Modes Demo"
-    subtitle="Compare error and warning visibility timing across supported display modes."
+    subtitle="Compare error and warning visibility timing across display modes."
   />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
 
   <ngx-form-page-layout>
     <div layout-aside class="sidebar-card-stack">

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.page.html
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.page.html
@@ -24,11 +24,8 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="formBody.formState()"
-        [warnings]="formBody.warnings()"
-        [validatedFields]="formBody.validatedFields()"
-        [pending]="formBody.pending()"
-      />
+        [feedback]="formBody.feedback"
+        />
     </div>
 
     <div layout-main>

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.page.ts
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.page.ts
@@ -1,9 +1,11 @@
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { DisplayModesDemoModel } from '../../models/display-modes-demo.model';
 import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
+import { displayModesContent } from './display-modes-demo.content';
 import { DisplayModesDemoFormBody } from './display-modes-demo.form';
 import { displayModesDemoSuite } from './display-modes-demo.validations';
 
@@ -11,6 +13,7 @@ import { displayModesDemoSuite } from './display-modes-demo.validations';
   selector: 'ngx-display-modes-demo-page',
   imports: [
     Card,
+    ExampleCardsComponent,
     FormPageLayout,
     PageTitle,
     FormStateCardComponent,
@@ -21,6 +24,8 @@ import { displayModesDemoSuite } from './display-modes-demo.validations';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DisplayModesDemoPageComponent {
+  protected readonly exampleContent = displayModesContent;
+
   protected readonly formValue = signal<DisplayModesDemoModel>({});
 
   protected readonly suite = displayModesDemoSuite;

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.page.ts
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.page.ts
@@ -1,4 +1,8 @@
 import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  NGX_ERROR_DISPLAY_MODE_TOKEN,
+  NGX_WARNING_DISPLAY_MODE_TOKEN,
+} from 'ngx-vest-forms';
 import { DisplayModesDemoModel } from '../../models/display-modes-demo.model';
 import { Card } from '../../ui/card/card.component';
 import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
@@ -21,6 +25,16 @@ import { displayModesDemoSuite } from './display-modes-demo.validations';
   ],
   templateUrl: './display-modes-demo.page.html',
   styleUrls: ['./display-modes-demo.page.scss'],
+  providers: [
+    {
+      provide: NGX_ERROR_DISPLAY_MODE_TOKEN,
+      useValue: 'on-submit',
+    },
+    {
+      provide: NGX_WARNING_DISPLAY_MODE_TOKEN,
+      useValue: 'on-touch',
+    },
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DisplayModesDemoPageComponent {

--- a/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.validations.ts
+++ b/apps/examples/src/app/pages/display-modes-demo/display-modes-demo.validations.ts
@@ -5,6 +5,10 @@ import { DisplayModesDemoModel } from '../../models/display-modes-demo.model';
 export const displayModesDemoSuite: NgxVestSuite<DisplayModesDemoModel> =
   create((model: DisplayModesDemoModel) => {
     // Error validations
+    test('tokenDefaultError', 'This field is required', () => {
+      enforce(model.tokenDefaultError).isNotBlank();
+    });
+
     test('alwaysError', 'This field is required', () => {
       enforce(model.alwaysError).isNotBlank();
     });
@@ -18,6 +22,11 @@ export const displayModesDemoSuite: NgxVestSuite<DisplayModesDemoModel> =
     });
 
     // Warning validations
+    test('tokenDefaultWarning', 'Username should be at least 5 characters', () => {
+      warn();
+      enforce(model.tokenDefaultWarning).longerThanOrEquals(5);
+    });
+
     test('alwaysWarning', 'Username should be at least 5 characters', () => {
       warn();
       enforce(model.alwaysWarning).longerThanOrEquals(5);

--- a/apps/examples/src/app/pages/native-schema-demo/README.md
+++ b/apps/examples/src/app/pages/native-schema-demo/README.md
@@ -1,0 +1,53 @@
+# Native Vest Schema Demo
+
+Route: `native-schema-demo` · Title: "Native Vest Schema Demo"
+
+## What & why
+
+This page shows how to give a Vest suite a **native structural schema** without
+reaching for an external schema library. The schema is built with Vest's own
+`n4s/enforce` primitives (`enforce.shape`, `enforce.optional`, `enforce.isString`,
+`enforce.isNumber`) and passed directly as the second argument to `create()`:
+
+```ts
+create((model) => { /* test() rules */ }, nativeVestSchema);
+```
+
+The schema keeps the model structurally safe and typed, while field-level
+`test()` callbacks carry the user-facing business rules and messages. This is
+the recommended approach in Vest 6.3.x for schema-aware suites — contrast it
+with the sibling **Zod Schema Demo**, which keeps an external schema separate
+from the suite.
+
+## ngx-vest-forms public APIs showcased
+
+- `provideFormContract(nativeSchemaDemoContract)` — registers the shape contract
+  for the form body.
+- `NgxVestForms` — template directives (`scVestForm`, `[ngModel]`, control
+  wrappers) used by the form HTML.
+- `FormDirective<NativeSchemaDemoModel>` — accessed via `viewChild` to read
+  `formState()`.
+- `createFormFeedbackSignals` / `createEmptyFormState` — derive `formState`,
+  `warnings`, `validatedFields`, and `pending` for the sidebar state card.
+- `NgxVestSuite<T>` — typed suite contract.
+
+## Key files
+
+- `native-schema-demo.validations.ts` — the `enforce.shape(...)` schema plus the
+  Vest suite (`nativeSchemaDemoSuite`).
+- `native-schema-demo.form.ts` / `.form.html` — the form body component bound to
+  the suite and contract.
+- `native-schema-demo.page.ts` / `.page.html` — page shell, title, sidebar
+  explanation, and form state card.
+- `native-schema-demo.content.ts` — typed `ExampleContent` rendered by
+  `<ngx-example-cards>`.
+
+## Behavior
+
+`ngx-vest-forms` validates one field at a time via
+`suite.only(field).run(model)`. Because the model is partial during typing, the
+schema marks every property `enforce.optional(...)`, so a focused run never
+fails purely because sibling fields are absent. The nested `address` object is
+described once inside the schema instead of being duplicated in an external
+contract, and business rules (required fields, email pattern, age 18–120, ZIP
+4–6 digits) live in `test()` callbacks close to the form UI.

--- a/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.content.ts
+++ b/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.content.ts
@@ -29,7 +29,7 @@ export const nativeSchemaContent = defineExampleContent({
         title: 'Schema vs. business rules',
         points: [
           'Keep the schema for shape/type safety and reserve test() callbacks for user-facing business messages',
-          'Wire the suite into the form with provideFormContract so each field validates via suite.only(field).run(model)',
+          'Bind the schema directly through [formContract] so the example showcases the v3 public API instead of a DI-only pattern',
         ],
       },
     ],

--- a/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.content.ts
+++ b/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.content.ts
@@ -1,0 +1,38 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const nativeSchemaContent = defineExampleContent({
+  demonstrates: {
+    icon: '🧬',
+    title: 'What this demonstrates',
+    points: [
+      'A native Vest schema built with enforce.shape(...) and passed directly as the 2nd argument to create((model) => { ... }, schema)',
+      'Structural typing for a nested model (firstName, lastName, email, age, address.street/city/zipCode) without an external schema library',
+      'enforce.optional() wrappers so focused runs against partial models stay valid while a field is still being typed',
+      'Field-level test() callbacks layering business rules (required, email pattern, age 18–120, ZIP 4–6 digits) on top of the schema',
+      'Nested address validation declared once in the schema instead of repeated in a separate contract',
+      'ngx-vest-forms narrowing the schema per field via suite.only(field).run(model) for safe partial validation',
+      'Live form state, warnings, validated fields, and pending status surfaced through createFormFeedbackSignals',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Native Vest schemas',
+        points: [
+          'Define a structural contract with enforce.shape(...) and nest enforce.shape for sub-objects like address',
+          'Pass the schema as the second create() argument so Vest enforces shape and types alongside your tests',
+          'Use enforce.optional() so partial models from focused field runs do not fail schema validation prematurely',
+        ],
+      },
+      {
+        title: 'Schema vs. business rules',
+        points: [
+          'Keep the schema for shape/type safety and reserve test() callbacks for user-facing business messages',
+          'Wire the suite into the form with provideFormContract so each field validates via suite.only(field).run(model)',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Zod schema', route: 'zod-schema-demo' },
+  },
+});

--- a/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.form.html
+++ b/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.form.html
@@ -3,6 +3,7 @@
     ngxVestForm
     #vestForm="ngxVestForm"
     [suite]="suite()"
+    [formContract]="formContract"
     [formValue]="formValue()"
     (formValueChange)="formValueChange.emit($event)"
     (errorsChange)="currentErrors.set($event)"

--- a/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.form.ts
+++ b/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.form.ts
@@ -13,7 +13,6 @@ import {
   FormDirective,
   NgxVestForms,
   NgxVestSuite,
-  provideFormContract,
 } from 'ngx-vest-forms';
 import {
   NativeSchemaDemoModel,
@@ -26,12 +25,12 @@ import { FormSectionComponent } from '../../ui/form-section/form-section.compone
   selector: 'ngx-native-schema-demo-form-body',
   imports: [NgxVestForms, Card, FormSectionComponent],
   templateUrl: './native-schema-demo.form.html',
-  providers: [provideFormContract(nativeSchemaDemoContract)],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class NativeSchemaDemoFormBody {
   readonly formValue = input.required<NativeSchemaDemoModel>();
   readonly suite = input.required<NgxVestSuite<NativeSchemaDemoModel>>();
+  readonly formContract = nativeSchemaDemoContract;
 
   readonly formValueChange = output<NativeSchemaDemoModel>();
   readonly submitted = output();
@@ -41,7 +40,7 @@ export class NativeSchemaDemoFormBody {
   });
 
   protected readonly currentErrors = signal<Record<string, string[]>>({});
-  private readonly formFeedback = createFormFeedbackSignals(this.vestForm, {
+  readonly feedback = createFormFeedbackSignals(this.vestForm, {
     formState: computed(() => {
       const state = this.vestForm()?.formState();
       if (!state) return createEmptyFormState<NativeSchemaDemoModel>();
@@ -49,11 +48,7 @@ export class NativeSchemaDemoFormBody {
     }),
   });
 
-  readonly formState = this.formFeedback.formState;
-  readonly warnings = this.formFeedback.warnings;
-  readonly validatedFields = this.formFeedback.validatedFields;
-  readonly pending = this.formFeedback.pending;
-
+        
   protected onSubmit(): void {
     this.submitted.emit();
   }

--- a/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.page.html
+++ b/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.page.html
@@ -4,6 +4,8 @@
     subtitle="Use create(..., enforce.shape(...)) for built-in schema validation alongside field-level business rules."
   />
 
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
   <ngx-form-page-layout>
     <div layout-aside class="sidebar-card-stack">
       <ngx-card title="How Native Schemas Work">

--- a/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.page.html
+++ b/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.page.html
@@ -37,11 +37,8 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="formBody.formState()"
-        [warnings]="formBody.warnings()"
-        [validatedFields]="formBody.validatedFields()"
-        [pending]="formBody.pending()"
-      />
+        [feedback]="formBody.feedback"
+        />
     </div>
 
     <div layout-main>

--- a/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.page.ts
+++ b/apps/examples/src/app/pages/native-schema-demo/native-schema-demo.page.ts
@@ -3,7 +3,9 @@ import { NativeSchemaDemoModel } from '../../models/native-schema-demo.model';
 import { Card } from '../../ui/card/card.component';
 import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
+import { nativeSchemaContent } from './native-schema-demo.content';
 import { NativeSchemaDemoFormBody } from './native-schema-demo.form';
 import { nativeSchemaDemoSuite } from './native-schema-demo.validations';
 
@@ -11,6 +13,7 @@ import { nativeSchemaDemoSuite } from './native-schema-demo.validations';
   selector: 'ngx-native-schema-demo-page',
   imports: [
     Card,
+    ExampleCardsComponent,
     FormPageLayout,
     FormStateCardComponent,
     PageTitle,
@@ -23,6 +26,8 @@ export class NativeSchemaDemoPageComponent {
   protected readonly formValue = signal<NativeSchemaDemoModel>({});
 
   protected readonly suite = nativeSchemaDemoSuite;
+
+  protected readonly exampleContent = nativeSchemaContent;
 
   protected save(): void {
     // Intentionally no console output in examples to keep CI and demos quiet

--- a/apps/examples/src/app/pages/purchase-form/README.md
+++ b/apps/examples/src/app/pages/purchase-form/README.md
@@ -1,0 +1,63 @@
+# Purchase Form
+
+A near-complete checkout flow that exercises most of the ngx-vest-forms surface
+in one place: conditional fields, cross-field rules, async uniqueness, a
+form-level rule, imperative helpers, and a resilient remote data load.
+
+## Why it exists
+
+Most demos isolate a single concept. This page is the opposite: a realistic,
+busy form where many features have to coexist without fighting each other. It is
+the reference for "how do all of these pieces fit together in a real form".
+
+## What it does
+
+- Collects identity, an age-gated emergency contact, gender (with an "other"
+  free-text branch), a product and quantity, billing and optional shipping
+  addresses, a password pair, and a dynamic list of phone numbers.
+- Validates a **User ID** asynchronously against a mock SWAPI-style service. The
+  test is wrapped in Vest `memo()` and cancels the in-flight request when the
+  validation `signal` aborts.
+- Enforces **cross-field** rules: passwords must match, and the billing and
+  shipping addresses must not be identical when shipping differs.
+- Enforces a **ROOT_FORM** rule ("Brecht is not 30 anymore") that spans
+  `firstName`, `lastName`, and `age`.
+- Emits **non-blocking warnings** (`warn()`) for weak passwords alongside the
+  blocking "password is required" error.
+- "Fetch Luke" loads demo data through Angular `httpResource`. A toolbar lets
+  you choose a success response or a simulated failure (random, 404, 401, 500,
+  network). On error the fetched fields are cleared via `clearFields()`.
+- "Clear Sensitive Data" wipes passwords and identity fields; "Prefill Billing
+  Address" writes deep paths with `setValueAtPath()`.
+
+## ngx-vest-forms APIs showcased
+
+- `NgxVestForms`, `FormDirective`, `provideFormContract`
+- `createValidationConfig()` with `.bidirectional()` and `.whenChanged()`,
+  rebuilt reactively from the current form value
+- `createFormFeedbackSignals()` for packaged `formState`, `warnings`,
+  `validatedFields`, and `pending`
+- `clearFields()`, `setValueAtPath()`
+- `FormDirective.focusFirstInvalidControl()`, `resetForm()`
+- `ROOT_FORM` token for form-level errors
+- `NGX_VALIDATION_DEBOUNCE_PRESETS` (`typing` and `async`)
+- `NgxVestSuite` / Vest `create`, `test`, `enforce`, `omitWhen`, `warn`,
+  `memo`
+
+## Key files
+
+- `purchase.page.ts` / `.html` — page shell, toolbar, and form-state card
+- `purchase.form.ts` / `.html` — the form component, fetch logic, helpers
+- `purchase.validations.ts` — the Vest suite and error/warning rule maps
+- `purchase.validations.spec.ts` — suite unit tests
+- `swapi.service.ts`, `product.service.ts` — mock data sources
+- `../../models/purchase-form.model.ts` — model, contract, initial value
+
+## Behaviour notes
+
+- Typing "Luke" as the first name auto-triggers the data fetch; a manual fetch
+  temporarily overrides that.
+- Typing "Brecht Billiet" auto-fills some fields to make the ROOT_FORM rule and
+  password mismatch easy to observe.
+- `validationConfig` is a `computed` — extra dependencies (gender → genderOther,
+  quantity ↔ justification) are added only when those branches are active.

--- a/apps/examples/src/app/pages/purchase-form/purchase.content.ts
+++ b/apps/examples/src/app/pages/purchase-form/purchase.content.ts
@@ -1,0 +1,48 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const purchaseContent = defineExampleContent({
+  demonstrates: {
+    icon: '🛒',
+    title: 'What this demonstrates',
+    points: [
+      'A full checkout form: identity, age-gated emergency contact, gender, product/quantity, billing & shipping addresses, passwords, and phone numbers',
+      'Async uniqueness check on User ID via Vest memo() with an abort-aware request that cancels on signal',
+      'Cross-field rules: password ↔ confirm-password match, and a guard that billing and shipping addresses are not identical',
+      'Conditional validation with omitWhen: emergency contact under 18, "other" gender detail, justification when quantity exceeds 5, shipping address only when it differs from billing',
+      'A ROOT_FORM rule ("Brecht is not 30 anymore") proving form-level validation across multiple fields',
+      'Non-blocking password-strength warnings via warn() shown alongside blocking errors',
+      'Imperative form helpers: clearFields() to wipe sensitive data, setValueAtPath() to prefill the billing address, and focusFirstInvalidControl() on submit',
+      'httpResource-driven "Fetch Luke" data load with selectable failure scenarios (404, 401, 500, network) that clear fetched fields on error',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Conditional & cross-field validation',
+        points: [
+          'Use omitWhen to make whole fields required only under runtime conditions',
+          'Wire dependent fields with createValidationConfig().bidirectional() and .whenChanged() so a change re-runs the partner',
+          'Build the validationConfig dynamically based on current form values',
+        ],
+      },
+      {
+        title: 'Async & ROOT_FORM rules',
+        points: [
+          'Debounce async validation with NGX_VALIDATION_DEBOUNCE_PRESETS.async',
+          'Wrap async tests in Vest memo() and abort in-flight requests via the test signal',
+          'Surface form-level (ROOT_FORM) errors separately from field errors',
+        ],
+      },
+      {
+        title: 'Programmatic form manipulation',
+        points: [
+          'clearFields() to reset nested groups like passwords without rebuilding the model',
+          'setValueAtPath() to write deep paths such as addresses.billingAddress.street',
+          'focusFirstInvalidControl() to drive accessible submit-time navigation',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Submission patterns', route: 'submission-patterns' },
+  },
+});

--- a/apps/examples/src/app/pages/purchase-form/purchase.form.ts
+++ b/apps/examples/src/app/pages/purchase-form/purchase.form.ts
@@ -99,7 +99,7 @@ export class PurchaseForm {
 
   private readonly vestForm =
     viewChild<FormDirective<PurchaseFormModel>>('vestForm');
-  private readonly formFeedback = createFormFeedbackSignals(this.vestForm);
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
 
   protected readonly formValue = signal<PurchaseFormModel>(
     initialPurchaseFormValue
@@ -112,21 +112,17 @@ export class PurchaseForm {
   readonly saveRequested = output<PurchaseFormModel>();
 
   /** Exposes the directive's packaged form state. */
-  readonly formState = this.formFeedback.formState;
-
+  
   /** Exposes field warnings as a plain Record for presentational components. */
-  readonly warnings = this.formFeedback.warnings;
-
+  
   /**
    * Field paths that have been validated (touched/blurred or submitted).
    * Delegates to the FormDirective's touchedFieldPaths signal which
    * reactively tracks TouchedChangeEvent from the form tree.
    */
-  readonly validatedFields = this.formFeedback.validatedFields;
-
+  
   /** True while async validation is in progress. */
-  readonly pending = this.formFeedback.pending;
-
+  
   /**
    * Automatically fetch demo data when the first name becomes "Luke".
    * A manual request can temporarily override this to demonstrate both

--- a/apps/examples/src/app/pages/purchase-form/purchase.form.ts
+++ b/apps/examples/src/app/pages/purchase-form/purchase.form.ts
@@ -111,18 +111,6 @@ export class PurchaseForm {
   readonly formValueChange = output<PurchaseFormModel>();
   readonly saveRequested = output<PurchaseFormModel>();
 
-  /** Exposes the directive's packaged form state. */
-  
-  /** Exposes field warnings as a plain Record for presentational components. */
-  
-  /**
-   * Field paths that have been validated (touched/blurred or submitted).
-   * Delegates to the FormDirective's touchedFieldPaths signal which
-   * reactively tracks TouchedChangeEvent from the form tree.
-   */
-  
-  /** True while async validation is in progress. */
-  
   /**
    * Automatically fetch demo data when the first name becomes "Luke".
    * A manual request can temporarily override this to demonstrate both

--- a/apps/examples/src/app/pages/purchase-form/purchase.page.html
+++ b/apps/examples/src/app/pages/purchase-form/purchase.page.html
@@ -4,6 +4,8 @@
     subtitle="Complete a full checkout flow with conditional and cross-field validation."
   />
 
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
   <div class="grid gap-8 xl:grid-cols-[280px_minmax(0,1fr)]">
     <aside class="sidebar-card-stack">
       <ngx-card title="Form Features">

--- a/apps/examples/src/app/pages/purchase-form/purchase.page.html
+++ b/apps/examples/src/app/pages/purchase-form/purchase.page.html
@@ -92,13 +92,10 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="purchaseForm.formState()"
-        [warnings]="purchaseForm.warnings()"
+        [feedback]="purchaseForm.feedback"
         [validationErrorRules]="validationErrorRules"
         [validationWarningRules]="validationWarningRules"
-        [validatedFields]="purchaseForm.validatedFields()"
-        [pending]="purchaseForm.pending()"
-      />
+        />
     </aside>
 
     <section class="space-y-6">

--- a/apps/examples/src/app/pages/purchase-form/purchase.page.ts
+++ b/apps/examples/src/app/pages/purchase-form/purchase.page.ts
@@ -10,7 +10,9 @@ import { PurchaseFormModel } from '../../models/purchase-form.model';
 import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
 import { Card } from '../../ui/card/card.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
+import { purchaseContent } from './purchase.content';
 import { FetchErrorScenario, PurchaseForm } from './purchase.form';
 import {
   purchaseValidationErrorRulesByField,
@@ -21,13 +23,22 @@ type FetchLukeMode = 'normal' | FetchErrorScenario;
 
 @Component({
   selector: 'ngx-purchase-page',
-  imports: [Card, PageTitle, AlertPanel, FormStateCardComponent, PurchaseForm],
+  imports: [
+    Card,
+    PageTitle,
+    AlertPanel,
+    FormStateCardComponent,
+    PurchaseForm,
+    ExampleCardsComponent,
+  ],
   templateUrl: './purchase.page.html',
   styleUrls: ['./purchase.page.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PurchasePageComponent {
   private readonly purchaseForm = viewChild(PurchaseForm);
+
+  protected readonly exampleContent = purchaseContent;
 
   protected readonly fetchLukeModes: Array<{
     label: string;

--- a/apps/examples/src/app/pages/purchase-form/purchase.page.ts
+++ b/apps/examples/src/app/pages/purchase-form/purchase.page.ts
@@ -36,6 +36,7 @@ type FetchLukeMode = 'normal' | FetchErrorScenario;
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PurchasePageComponent {
+  protected readonly feedback = computed(() => this.purchaseForm()?.feedback);
   private readonly purchaseForm = viewChild(PurchaseForm);
 
   protected readonly exampleContent = purchaseContent;
@@ -67,7 +68,7 @@ export class PurchasePageComponent {
   protected readonly validationWarningRules =
     purchaseValidationWarningRulesByField;
   protected readonly rootFormErrors = computed(
-    () => this.purchaseForm()?.formState()?.errors[ROOT_FORM] || []
+    () => this.feedback()?.formState()?.errors[ROOT_FORM] || []
   );
 
   protected fetchLuke(mode: string): void {

--- a/apps/examples/src/app/pages/starter-form/README.md
+++ b/apps/examples/src/app/pages/starter-form/README.md
@@ -1,0 +1,51 @@
+# Starter Contact Form
+
+The canonical "start here" demo. It is the smallest honest ngx-vest-forms
+setup — copy it into a new app and you have a working, validated,
+accessible form.
+
+## Why this demo exists
+
+New visitors need one trustworthy baseline rather than a tour of advanced
+features. Every other demo in this app builds on the wiring shown here.
+
+## What it shows
+
+- A single `ngxVestForm` directive on a native `<form>`.
+- A typed model (`StarterFormModel`) declared with `NgxDeepPartial`, and its
+  matching contract (`starterFormShape`) supplied through
+  `provideFormContract` so the directive can warn (in dev) about `name`
+  attributes that drift from the model.
+- A plain Vest suite (`starter.validations.ts`) wired in through the
+  `[suite]` input. The suite has no Angular dependency and is unit-testable
+  on its own: `starterFormSuite({ name: '' })`.
+- The form value owned by the page as a `signal`, kept in sync through
+  `(formValueChange)` — no reactive forms, no `FormGroup`.
+- `ngx-control-wrapper` rendering label + input + error message with the
+  default on-blur error timing.
+- A non-blocking `warn()` rule on the message field: guidance that never
+  prevents submission.
+- Reading packaged form state via `createFormFeedbackSignals` for the live
+  state panel.
+
+## Public API used
+
+`NgxVestForms`, `FormDirective`, `provideFormContract`,
+`createFormFeedbackSignals`, `NgxDeepPartial`, `NgxDeepRequired`,
+`NgxVestSuite`.
+
+## Key files
+
+| File | Responsibility |
+| --- | --- |
+| `starter.page.ts` / `.html` | Self-contained page + form |
+| `starter.validations.ts` | Vest suite (testable in isolation) |
+| `../../models/starter-form.model.ts` | Model + contract |
+| `starter.content.ts` | "What this demonstrates / learn" cards |
+
+## Behavior
+
+Submitting while invalid keeps the success panel hidden and surfaces field
+errors on the touched fields. Submitting a valid form shows a success panel
+echoing the submitted name and email. Reset clears both the form and the
+success panel.

--- a/apps/examples/src/app/pages/starter-form/starter.content.ts
+++ b/apps/examples/src/app/pages/starter-form/starter.content.ts
@@ -1,0 +1,39 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const starterContent = defineExampleContent({
+  demonstrates: {
+    icon: '🚀',
+    title: 'What this demonstrates',
+    points: [
+      'The minimal end-to-end ngx-vest-forms setup: one ngxVestForm, one Vest suite',
+      'Template-driven fields bound with [ngModel] inside ngx-control-wrapper',
+      'A typed NgxDeepPartial model plus a form contract via provideFormContract',
+      'On-blur error display with a non-blocking warning that never blocks submit',
+      'Reading packaged form state with createFormFeedbackSignals',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'The canonical wiring',
+        points: [
+          'Why the form value lives in a signal the page owns',
+          'How (formValueChange) keeps the model in sync without reactive forms',
+          'Where the Vest suite plugs in via the [suite] input',
+        ],
+      },
+      {
+        title: 'Copy this baseline',
+        points: [
+          'Every public symbol used here is part of the supported API surface',
+          'Suites are plain Vest specs you can unit-test without rendering',
+        ],
+      },
+    ],
+    nextStep: {
+      label: 'Next: Async username validation',
+      route: 'async-username',
+    },
+  },
+});

--- a/apps/examples/src/app/pages/starter-form/starter.form.html
+++ b/apps/examples/src/app/pages/starter-form/starter.form.html
@@ -1,0 +1,67 @@
+<form
+  ngxVestForm
+  #vestForm="ngxVestForm"
+  [suite]="suite()"
+  [formValue]="formValue()"
+  (formValueChange)="formValueChange.emit($event)"
+  (ngSubmit)="onSubmit()"
+  class="space-y-6"
+>
+  <ngx-control-wrapper class="form-field">
+    <label for="name" class="label-text">Name</label>
+    <input
+      class="input-field"
+      type="text"
+      id="name"
+      name="name"
+      [ngModel]="formValue().name"
+      placeholder="Ada Lovelace"
+      autocomplete="name"
+    />
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label for="email" class="label-text">Email</label>
+    <input
+      class="input-field"
+      type="email"
+      id="email"
+      name="email"
+      [ngModel]="formValue().email"
+      placeholder="ada@example.com"
+      autocomplete="email"
+      inputmode="email"
+    />
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label for="subject" class="label-text">Subject</label>
+    <input
+      class="input-field"
+      type="text"
+      id="subject"
+      name="subject"
+      [ngModel]="formValue().subject"
+      placeholder="How can we help?"
+    />
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label for="message" class="label-text">Message</label>
+    <textarea
+      class="input-field"
+      id="message"
+      name="message"
+      rows="4"
+      [ngModel]="formValue().message"
+      placeholder="Tell us a little about what you need…"
+    ></textarea>
+  </ngx-control-wrapper>
+
+  <div class="flex justify-end gap-3 pt-2">
+    <button type="button" class="btn btn-secondary" (click)="onReset()">
+      Reset
+    </button>
+    <button type="submit" class="btn btn-primary">Send message</button>
+  </div>
+</form>

--- a/apps/examples/src/app/pages/starter-form/starter.form.ts
+++ b/apps/examples/src/app/pages/starter-form/starter.form.ts
@@ -1,0 +1,55 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxVestForms,
+  NgxVestSuite,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  StarterFormModel,
+  starterFormShape,
+} from '../../models/starter-form.model';
+
+@Component({
+  selector: 'ngx-starter-form-body',
+  imports: [NgxVestForms],
+  templateUrl: './starter.form.html',
+  providers: [provideFormContract(starterFormShape)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StarterFormBody {
+  readonly formValue = input.required<StarterFormModel>();
+  readonly suite = input.required<NgxVestSuite<StarterFormModel>>();
+
+  readonly formValueChange = output<StarterFormModel>();
+  readonly submitted = output();
+  readonly resetRequested = output();
+
+  private readonly vestForm =
+    viewChild<FormDirective<StarterFormModel>>('vestForm');
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+        
+  protected onSubmit(): void {
+    this.submitted.emit();
+  }
+
+  protected onReset(): void {
+    this.resetRequested.emit();
+  }
+
+  resetFormState(value: StarterFormModel): void {
+    this.vestForm()?.resetForm(value);
+  }
+
+  focusFirstInvalidControl(): void {
+    this.vestForm()?.focusFirstInvalidControl();
+  }
+}

--- a/apps/examples/src/app/pages/starter-form/starter.page.html
+++ b/apps/examples/src/app/pages/starter-form/starter.page.html
@@ -17,12 +17,7 @@
         </ul>
       </ngx-card>
 
-      <ngx-form-state-card
-        [formState]="formState()"
-        [warnings]="warnings()"
-        [validatedFields]="validatedFields()"
-        [pending]="pending()"
-      />
+      <ngx-form-state-card [feedback]="feedback()" />
     </div>
 
     <div layout-main>
@@ -39,81 +34,13 @@
         title="Contact us"
         subtitle="All fields are required. Try submitting empty to see validation."
       >
-        <form
-          ngxVestForm
-          #vestForm="ngxVestForm"
-          [suite]="suite"
+        <ngx-starter-form-body
           [formValue]="formValue()"
+          [suite]="suite"
           (formValueChange)="formValue.set($event)"
-          (ngSubmit)="onSubmit()"
-          class="space-y-6"
-        >
-          <ngx-control-wrapper class="form-field">
-            <label>
-              <span class="label-text">Name</span>
-              <input
-                class="input-field"
-                type="text"
-                id="name"
-                name="name"
-                [ngModel]="formValue().name"
-                placeholder="Ada Lovelace"
-                autocomplete="name"
-              />
-            </label>
-          </ngx-control-wrapper>
-
-          <ngx-control-wrapper class="form-field">
-            <label>
-              <span class="label-text">Email</span>
-              <input
-                class="input-field"
-                type="email"
-                id="email"
-                name="email"
-                [ngModel]="formValue().email"
-                placeholder="ada@example.com"
-                autocomplete="email"
-                inputmode="email"
-              />
-            </label>
-          </ngx-control-wrapper>
-
-          <ngx-control-wrapper class="form-field">
-            <label>
-              <span class="label-text">Subject</span>
-              <input
-                class="input-field"
-                type="text"
-                id="subject"
-                name="subject"
-                [ngModel]="formValue().subject"
-                placeholder="How can we help?"
-              />
-            </label>
-          </ngx-control-wrapper>
-
-          <ngx-control-wrapper class="form-field">
-            <label>
-              <span class="label-text">Message</span>
-              <textarea
-                class="input-field"
-                id="message"
-                name="message"
-                rows="4"
-                [ngModel]="formValue().message"
-                placeholder="Tell us a little about what you need…"
-              ></textarea>
-            </label>
-          </ngx-control-wrapper>
-
-          <div class="flex justify-end gap-3 pt-2">
-            <button type="button" class="btn btn-secondary" (click)="reset()">
-              Reset
-            </button>
-            <button type="submit" class="btn btn-primary">Send message</button>
-          </div>
-        </form>
+          (submitted)="onSubmit()"
+          (resetRequested)="reset()"
+        />
       </ngx-card>
     </div>
   </ngx-form-page-layout>

--- a/apps/examples/src/app/pages/starter-form/starter.page.html
+++ b/apps/examples/src/app/pages/starter-form/starter.page.html
@@ -1,0 +1,120 @@
+<div class="page-container">
+  <ngx-page-title
+    title="Starter Contact Form"
+    subtitle="The canonical ngx-vest-forms setup — copy this as a trustworthy baseline."
+  />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
+  <ngx-form-page-layout>
+    <div layout-aside class="sidebar-card-stack">
+      <ngx-card title="Why start here">
+        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-200">
+          <li>One <code>ngxVestForm</code>, one Vest suite — nothing else.</li>
+          <li>Public API only. Safe to copy into your app.</li>
+          <li>Errors appear on blur; the message hint is advisory.</li>
+          <li>The form value is a signal the page owns.</li>
+        </ul>
+      </ngx-card>
+
+      <ngx-form-state-card
+        [formState]="formState()"
+        [warnings]="warnings()"
+        [validatedFields]="validatedFields()"
+        [pending]="pending()"
+      />
+    </div>
+
+    <div layout-main>
+      @if (submittedValue(); as submitted) {
+        <ngx-alert-panel tone="success" title="Message sent">
+          <p>
+            Thanks {{ submitted.name }} — we'll reply to
+            <strong>{{ submitted.email }}</strong> shortly.
+          </p>
+        </ngx-alert-panel>
+      }
+
+      <ngx-card
+        title="Contact us"
+        subtitle="All fields are required. Try submitting empty to see validation."
+      >
+        <form
+          ngxVestForm
+          #vestForm="ngxVestForm"
+          [suite]="suite"
+          [formValue]="formValue()"
+          (formValueChange)="formValue.set($event)"
+          (ngSubmit)="onSubmit()"
+          class="space-y-6"
+        >
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Name</span>
+              <input
+                class="input-field"
+                type="text"
+                id="name"
+                name="name"
+                [ngModel]="formValue().name"
+                placeholder="Ada Lovelace"
+                autocomplete="name"
+              />
+            </label>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Email</span>
+              <input
+                class="input-field"
+                type="email"
+                id="email"
+                name="email"
+                [ngModel]="formValue().email"
+                placeholder="ada@example.com"
+                autocomplete="email"
+                inputmode="email"
+              />
+            </label>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Subject</span>
+              <input
+                class="input-field"
+                type="text"
+                id="subject"
+                name="subject"
+                [ngModel]="formValue().subject"
+                placeholder="How can we help?"
+              />
+            </label>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Message</span>
+              <textarea
+                class="input-field"
+                id="message"
+                name="message"
+                rows="4"
+                [ngModel]="formValue().message"
+                placeholder="Tell us a little about what you need…"
+              ></textarea>
+            </label>
+          </ngx-control-wrapper>
+
+          <div class="flex justify-end gap-3 pt-2">
+            <button type="button" class="btn btn-secondary" (click)="reset()">
+              Reset
+            </button>
+            <button type="submit" class="btn btn-primary">Send message</button>
+          </div>
+        </form>
+      </ngx-card>
+    </div>
+  </ngx-form-page-layout>
+</div>

--- a/apps/examples/src/app/pages/starter-form/starter.page.ts
+++ b/apps/examples/src/app/pages/starter-form/starter.page.ts
@@ -1,18 +1,15 @@
 import {
   ChangeDetectionStrategy,
+  computed,
   Component,
   signal,
   viewChild,
 } from '@angular/core';
 import {
-  createFormFeedbackSignals,
-  FormDirective,
-  NgxVestForms,
-  provideFormContract,
+  createEmptyFormState,
 } from 'ngx-vest-forms';
 import {
   StarterFormModel,
-  starterFormShape,
 } from '../../models/starter-form.model';
 import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
 import { Card } from '../../ui/card/card.component';
@@ -21,29 +18,28 @@ import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.compo
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
 import { starterContent } from './starter.content';
+import { StarterFormBody } from './starter.form';
 import { starterFormSuite } from './starter.validations';
 
 /**
  * Canonical starter contact form — the default "start here" demo.
  *
- * Intentionally one self-contained component so it reads as a trustworthy
- * baseline a developer can copy: a single `ngxVestForm`, a plain Vest suite,
- * a form contract, and the standard control-wrapper markup. Uses the
- * ngx-vest-forms public API only.
+ * The page owns state, examples, and outcomes while the focused form markup
+ * lives beside it in `starter.form.html` so developers can inspect the form
+ * wiring without scanning page chrome. Uses the ngx-vest-forms public API only.
  */
 @Component({
   selector: 'ngx-starter-page',
   imports: [
-    NgxVestForms,
     PageTitle,
     Card,
     AlertPanel,
     FormPageLayout,
     FormStateCardComponent,
     ExampleCardsComponent,
+    StarterFormBody,
   ],
   templateUrl: './starter.page.html',
-  providers: [provideFormContract(starterFormShape)],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class StarterPageComponent {
@@ -54,18 +50,14 @@ export class StarterPageComponent {
   protected readonly formValue = signal<StarterFormModel>({});
   protected readonly submittedValue = signal<StarterFormModel | null>(null);
 
-  private readonly vestForm =
-    viewChild<FormDirective<StarterFormModel>>('vestForm');
-  private readonly feedback = createFormFeedbackSignals(this.vestForm);
+  private readonly formBody = viewChild(StarterFormBody);
 
-  protected readonly formState = this.feedback.formState;
-  protected readonly warnings = this.feedback.warnings;
-  protected readonly validatedFields = this.feedback.validatedFields;
-  protected readonly pending = this.feedback.pending;
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
 
   protected onSubmit(): void {
-    if (!this.formState()?.valid) {
+    if (!this.feedback()?.formState()?.valid) {
       this.submittedValue.set(null);
+      this.formBody()?.focusFirstInvalidControl();
       return;
     }
     this.submittedValue.set(structuredClone(this.formValue()));
@@ -73,7 +65,7 @@ export class StarterPageComponent {
 
   protected reset(): void {
     this.submittedValue.set(null);
-    this.vestForm()?.resetForm({});
+    this.formBody()?.resetFormState({});
     this.formValue.set({});
   }
 }

--- a/apps/examples/src/app/pages/starter-form/starter.page.ts
+++ b/apps/examples/src/app/pages/starter-form/starter.page.ts
@@ -1,0 +1,79 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  signal,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxVestForms,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  StarterFormModel,
+  starterFormShape,
+} from '../../models/starter-form.model';
+import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
+import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
+import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
+import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { PageTitle } from '../../ui/page-title/page-title.component';
+import { starterContent } from './starter.content';
+import { starterFormSuite } from './starter.validations';
+
+/**
+ * Canonical starter contact form — the default "start here" demo.
+ *
+ * Intentionally one self-contained component so it reads as a trustworthy
+ * baseline a developer can copy: a single `ngxVestForm`, a plain Vest suite,
+ * a form contract, and the standard control-wrapper markup. Uses the
+ * ngx-vest-forms public API only.
+ */
+@Component({
+  selector: 'ngx-starter-page',
+  imports: [
+    NgxVestForms,
+    PageTitle,
+    Card,
+    AlertPanel,
+    FormPageLayout,
+    FormStateCardComponent,
+    ExampleCardsComponent,
+  ],
+  templateUrl: './starter.page.html',
+  providers: [provideFormContract(starterFormShape)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class StarterPageComponent {
+  protected readonly exampleContent = starterContent;
+  protected readonly suite = starterFormSuite;
+
+  /** The form value is the single source of truth, owned by the page. */
+  protected readonly formValue = signal<StarterFormModel>({});
+  protected readonly submittedValue = signal<StarterFormModel | null>(null);
+
+  private readonly vestForm =
+    viewChild<FormDirective<StarterFormModel>>('vestForm');
+  private readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+  protected readonly formState = this.feedback.formState;
+  protected readonly warnings = this.feedback.warnings;
+  protected readonly validatedFields = this.feedback.validatedFields;
+  protected readonly pending = this.feedback.pending;
+
+  protected onSubmit(): void {
+    if (!this.formState()?.valid) {
+      this.submittedValue.set(null);
+      return;
+    }
+    this.submittedValue.set(structuredClone(this.formValue()));
+  }
+
+  protected reset(): void {
+    this.submittedValue.set(null);
+    this.vestForm()?.resetForm({});
+    this.formValue.set({});
+  }
+}

--- a/apps/examples/src/app/pages/starter-form/starter.validations.ts
+++ b/apps/examples/src/app/pages/starter-form/starter.validations.ts
@@ -1,0 +1,49 @@
+import { type NgxVestSuite } from 'ngx-vest-forms';
+import { create, enforce, omitWhen, test, warn } from 'vest';
+import { StarterFormModel } from '../../models/starter-form.model';
+
+/**
+ * The canonical Vest suite for the starter form.
+ *
+ * Suites are plain Vest specs — they have no Angular dependency and can be
+ * unit-tested in isolation by calling `starterFormSuite(model)` directly.
+ */
+export const starterFormSuite: NgxVestSuite<StarterFormModel> = create(
+  (model: StarterFormModel) => {
+    test('name', 'Name is required', () => {
+      enforce(model.name).isNotBlank();
+    });
+
+    test('email', 'Email is required', () => {
+      enforce(model.email).isNotBlank();
+    });
+
+    omitWhen(!model.email, () => {
+      test('email', 'Enter a valid email address', () => {
+        enforce(model.email ?? '').matches(
+          /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+        );
+      });
+    });
+
+    test('subject', 'Subject is required', () => {
+      enforce(model.subject).isNotBlank();
+    });
+
+    test('message', 'Message is required', () => {
+      enforce(model.message).isNotBlank();
+    });
+
+    // Advisory, non-blocking guidance: a short message is allowed but nudged.
+    omitWhen(!model.message, () => {
+      test(
+        'message',
+        'A little more detail helps us respond faster (aim for 20+ characters)',
+        () => {
+          warn();
+          enforce(model.message).longerThanOrEquals(20);
+        }
+      );
+    });
+  }
+);

--- a/apps/examples/src/app/pages/submission-patterns-form/README.md
+++ b/apps/examples/src/app/pages/submission-patterns-form/README.md
@@ -1,0 +1,66 @@
+# Submission Patterns
+
+A realistic account-creation form that models the **four submission
+concerns distinctly** so each can be reasoned about and copied on its own.
+The page never lets one concern leak into another.
+
+## The four concerns
+
+### (a) Field validation
+
+A plain Vest suite (`submission-patterns.validations.ts`): full name
+required, email required + format, password required + min 8 characters
+(with a non-blocking `warn()` nudge under 12), and `acceptTerms` must be
+true. The suite has no Angular dependency and is unit-testable on its own:
+`submissionPatternsSuite({ email: 'x' })`. Errors display on blur via
+`ngx-control-wrapper`.
+
+### (b) Submit-time INVALID handling
+
+`onSubmit()` checks `formState().valid` first. When the form is invalid the
+server is **never contacted**; instead the page stays in `editing` and calls
+`FormDirective.focusFirstInvalidControl()` to scroll to and focus the first
+failing control — the exact mechanism used by the Purchase demo. The call is
+wrapped in `afterNextRender` so submit-driven validation has flushed before
+the first-invalid target is resolved.
+
+### (c) Server FAILURE messaging
+
+Only a valid form reaches `AccountService.createAccount()`. HTTP failures
+are caught with `catchError`, the page moves to `server-error`, and the
+message renders in an `ngx-alert-panel` with `tone="error"` (which sets
+`role="alert"` + `aria-live="assertive"`). A **Retry** button re-submits the
+exact same value. Server failure is page state — it never pollutes the Vest
+suite.
+
+### (d) SUCCESS state + reset
+
+On 201 the page moves to `success` and a polite success panel echoes the
+returned account id with a **Create another** button that resets the form
+and returns to `editing`.
+
+These concerns are kept distinct by a single page signal:
+`'editing' | 'submitting' | 'server-error' | 'success'`.
+
+## Deterministic demo
+
+The aside scenario picker forces each path through the in-app mock
+(`POST /api/account`): Normal (201), Email already taken (sends a `taken`
+email → 409), Server error (`?errorScenario=server-error`), and Network
+error (`?errorScenario=network-error`).
+
+## Public API used
+
+`NgxVestForms`, `FormDirective` (`focusFirstInvalidControl`),
+`provideFormContract`, `createFormFeedbackSignals`, `NgxDeepPartial`,
+`NgxDeepRequired`, `NgxVestSuite`.
+
+## Key files
+
+| File | Responsibility |
+| --- | --- |
+| `submission-patterns.page.ts` / `.html` | Page + four-state machine |
+| `account.service.ts` | `POST /api/account` HTTP client |
+| `submission-patterns.validations.ts` | Vest suite (testable in isolation) |
+| `../../models/submission-patterns.model.ts` | Model + contract |
+| `submission-patterns.content.ts` | "What this demonstrates / learn" cards |

--- a/apps/examples/src/app/pages/submission-patterns-form/account.service.ts
+++ b/apps/examples/src/app/pages/submission-patterns-form/account.service.ts
@@ -1,0 +1,41 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { SubmissionPatternsModel } from '../../models/submission-patterns.model';
+
+/** Options accepted by {@link AccountService.createAccount}. */
+export type CreateAccountOptions = {
+  /**
+   * Forwarded to the mock API as `?errorScenario=` to deterministically
+   * simulate a server-side failure (`server-error`, `network-error`, …).
+   */
+  readonly errorScenario?: string;
+}
+
+/**
+ * Thin HTTP client for the account-creation endpoint backed by the in-app
+ * mock interceptor (`POST /api/account`). Mirrors the style of the other
+ * example services (swapi / auto-save): a single injected `HttpClient`,
+ * no error handling here — the page owns the success/failure state machine.
+ */
+@Injectable({ providedIn: 'root' })
+export class AccountService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly accountUrl = '/api/account';
+
+  /**
+   * Creates an account. Resolves with the new account `id` on success
+   * (HTTP 201) and errors with an `HttpErrorResponse` on failure
+   * (409 conflict for taken emails, or the simulated `errorScenario`).
+   */
+  createAccount(
+    model: SubmissionPatternsModel,
+    opts?: CreateAccountOptions
+  ): Observable<{ id: string }> {
+    const url = opts?.errorScenario
+      ? `${this.accountUrl}?errorScenario=${encodeURIComponent(opts.errorScenario)}`
+      : this.accountUrl;
+
+    return this.httpClient.post<{ id: string }>(url, model);
+  }
+}

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.content.ts
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.content.ts
@@ -5,8 +5,9 @@ export const submissionPatternsContent = defineExampleContent({
     icon: '📮',
     title: 'What this demonstrates',
     points: [
-      'Concern (a) — field validation: a plain Vest suite (required, email format, password length, accepted terms)',
+      'Concern (a) — field validation: a plain Vest suite (required, email format, password length, accepted terms) with submit-gated visibility for this demo',
       'Concern (b) — submit-time INVALID handling: an invalid submit never calls the server and moves focus to the first invalid control',
+      'Concern (b.1) — end the submit cycle with clearSubmittedState() so submit-only errors hide without resetting values or Angular control metadata',
       'Concern (c) — server FAILURE messaging: HTTP errors surface in an assertive error panel with a Retry button',
       'Concern (d) — SUCCESS state: a polite success panel echoes the new account id with a "Create another" reset',
       'A four-state page signal (editing / submitting / server-error / success) that keeps these concerns distinct',
@@ -20,6 +21,7 @@ export const submissionPatternsContent = defineExampleContent({
         points: [
           'Field validity is decided by the Vest suite; the server is only contacted once the form is valid',
           'focusFirstInvalidControl() on FormDirective guides keyboard and AT users after an invalid submit',
+          'clearSubmittedState() ends the submit gate without wiping the current values or touched history',
           'Server failure is page state, not validation state — it never pollutes the Vest suite',
         ],
       },

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.content.ts
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.content.ts
@@ -1,0 +1,39 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const submissionPatternsContent = defineExampleContent({
+  demonstrates: {
+    icon: '📮',
+    title: 'What this demonstrates',
+    points: [
+      'Concern (a) — field validation: a plain Vest suite (required, email format, password length, accepted terms)',
+      'Concern (b) — submit-time INVALID handling: an invalid submit never calls the server and moves focus to the first invalid control',
+      'Concern (c) — server FAILURE messaging: HTTP errors surface in an assertive error panel with a Retry button',
+      'Concern (d) — SUCCESS state: a polite success panel echoes the new account id with a "Create another" reset',
+      'A four-state page signal (editing / submitting / server-error / success) that keeps these concerns distinct',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Why the four concerns are separate',
+        points: [
+          'Field validity is decided by the Vest suite; the server is only contacted once the form is valid',
+          'focusFirstInvalidControl() on FormDirective guides keyboard and AT users after an invalid submit',
+          'Server failure is page state, not validation state — it never pollutes the Vest suite',
+        ],
+      },
+      {
+        title: 'Deterministic demos',
+        points: [
+          'The scenario picker forces Normal / Email taken (409) / Server error / Network error paths',
+          'Retry re-submits the exact same value; Create another resets cleanly to editing',
+        ],
+      },
+    ],
+    nextStep: {
+      label: 'Next: Complex nested form',
+      route: 'complex-nested',
+    },
+  },
+});

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.form.html
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.form.html
@@ -1,0 +1,74 @@
+<form
+  ngxVestForm
+  #vestForm="ngxVestForm"
+  [suite]="suite()"
+  [formValue]="formValue()"
+  (formValueChange)="formValueChange.emit($event)"
+  (ngSubmit)="onSubmit()"
+  class="space-y-6"
+>
+  <ngx-control-wrapper class="form-field">
+    <label for="fullName" class="label-text">Full name</label>
+    <input
+      class="input-field"
+      type="text"
+      id="fullName"
+      name="fullName"
+      [ngModel]="formValue().fullName"
+      placeholder="Ada Lovelace"
+      autocomplete="name"
+    />
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label for="email" class="label-text">Email</label>
+    <input
+      class="input-field"
+      type="email"
+      id="email"
+      name="email"
+      [ngModel]="formValue().email"
+      placeholder="ada@example.com"
+      autocomplete="email"
+      inputmode="email"
+    />
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label for="password" class="label-text">Password</label>
+    <input
+      class="input-field"
+      type="password"
+      id="password"
+      name="password"
+      [ngModel]="formValue().password"
+      placeholder="At least 8 characters"
+      autocomplete="new-password"
+    />
+  </ngx-control-wrapper>
+
+  <ngx-control-wrapper class="form-field">
+    <label class="flex items-center gap-2">
+      <input
+        type="checkbox"
+        id="acceptTerms"
+        name="acceptTerms"
+        [ngModel]="formValue().acceptTerms"
+      />
+      <span class="label-text">I accept the terms of service</span>
+    </label>
+  </ngx-control-wrapper>
+
+  <div class="flex justify-end gap-3 pt-2">
+    <button type="button" class="btn btn-secondary" (click)="onReset()">
+      Reset
+    </button>
+    <button type="submit" class="btn btn-primary" [disabled]="submitting()">
+      @if (submitting()) {
+        Creating account…
+      } @else {
+        Create account
+      }
+    </button>
+  </div>
+</form>

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.form.ts
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.form.ts
@@ -1,0 +1,67 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NGX_ERROR_DISPLAY_MODE_TOKEN,
+  NgxVestForms,
+  NgxVestSuite,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import {
+  SubmissionPatternsModel,
+  submissionPatternsShape,
+} from '../../models/submission-patterns.model';
+
+@Component({
+  selector: 'ngx-submission-patterns-form-body',
+  imports: [NgxVestForms],
+  templateUrl: './submission-patterns.form.html',
+  providers: [
+    provideFormContract(submissionPatternsShape),
+    {
+      provide: NGX_ERROR_DISPLAY_MODE_TOKEN,
+      useValue: 'on-submit',
+    },
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubmissionPatternsFormBody {
+  readonly formValue = input.required<SubmissionPatternsModel>();
+  readonly suite = input.required<NgxVestSuite<SubmissionPatternsModel>>();
+  readonly submitting = input(false);
+
+  readonly formValueChange = output<SubmissionPatternsModel>();
+  readonly submitted = output();
+  readonly resetRequested = output();
+
+  private readonly vestForm =
+    viewChild<FormDirective<SubmissionPatternsModel>>('vestForm');
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+        
+  protected onSubmit(): void {
+    this.submitted.emit();
+  }
+
+  protected onReset(): void {
+    this.resetRequested.emit();
+  }
+
+  clearSubmittedState(): void {
+    this.vestForm()?.clearSubmittedState();
+  }
+
+  focusFirstInvalidControl(): void {
+    this.vestForm()?.focusFirstInvalidControl();
+  }
+
+  resetFormState(value: SubmissionPatternsModel): void {
+    this.vestForm()?.resetForm(value);
+  }
+}

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.html
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.html
@@ -1,0 +1,177 @@
+<div class="page-container">
+  <ngx-page-title
+    title="Submission Patterns"
+    subtitle="Submit-time invalid handling, server-error messaging, success state, and retry — modelled distinctly."
+  />
+
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
+  <ngx-form-page-layout>
+    <div layout-aside class="sidebar-card-stack">
+      <ngx-card title="Simulated outcome">
+        <p class="mb-3 text-sm text-gray-600 dark:text-gray-300">
+          Pick how the mock server should respond so each path is
+          deterministic.
+        </p>
+        <label class="block">
+          <span
+            class="mb-1 block text-xs font-medium tracking-wide text-gray-500 uppercase dark:text-gray-400"
+          >
+            Server response
+          </span>
+          <select
+            #scenarioSelect
+            class="input-field"
+            [value]="scenario()"
+            (change)="onScenarioChange(scenarioSelect.value)"
+          >
+            @for (option of scenarios; track option.value) {
+              <option [value]="option.value">{{ option.label }}</option>
+            }
+          </select>
+        </label>
+        <ul
+          class="mt-4 space-y-2 text-sm text-gray-600 dark:text-gray-300"
+        >
+          <li>(a) Field errors appear on blur — pure Vest suite.</li>
+          <li>(b) Submitting invalid focuses the first bad field.</li>
+          <li>(c) Server failures surface in an alert with Retry.</li>
+          <li>(d) Success shows the new account id + Create another.</li>
+        </ul>
+      </ngx-card>
+
+      <ngx-form-state-card
+        [formState]="formState()"
+        [warnings]="warnings()"
+        [validatedFields]="validatedFields()"
+        [pending]="pending()"
+      />
+    </div>
+
+    <div layout-main>
+      @if (state() === 'success') {
+        <ngx-alert-panel tone="success" title="Account created">
+          <p>
+            Your account was created with id
+            <strong>{{ createdId() }}</strong
+            >.
+          </p>
+          <button
+            type="button"
+            class="btn btn-secondary mt-3"
+            (click)="reset()"
+          >
+            Create another
+          </button>
+        </ngx-alert-panel>
+      }
+
+      @if (state() === 'server-error') {
+        <ngx-alert-panel tone="error" title="Couldn't create your account">
+          <p>{{ serverError() }}</p>
+          <button
+            type="button"
+            class="btn btn-primary mt-3"
+            (click)="retry()"
+          >
+            Retry
+          </button>
+        </ngx-alert-panel>
+      }
+
+      <ngx-card
+        title="Create account"
+        subtitle="All fields are required. Submit while invalid to see focus jump to the first error."
+      >
+        <form
+          ngxVestForm
+          #vestForm="ngxVestForm"
+          [suite]="suite"
+          [formValue]="formValue()"
+          (formValueChange)="formValue.set($event)"
+          (ngSubmit)="onSubmit()"
+          class="space-y-6"
+        >
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Full name</span>
+              <input
+                class="input-field"
+                type="text"
+                id="fullName"
+                name="fullName"
+                [ngModel]="formValue().fullName"
+                placeholder="Ada Lovelace"
+                autocomplete="name"
+              />
+            </label>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Email</span>
+              <input
+                class="input-field"
+                type="email"
+                id="email"
+                name="email"
+                [ngModel]="formValue().email"
+                placeholder="ada@example.com"
+                autocomplete="email"
+                inputmode="email"
+              />
+            </label>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <label>
+              <span class="label-text">Password</span>
+              <input
+                class="input-field"
+                type="password"
+                id="password"
+                name="password"
+                [ngModel]="formValue().password"
+                placeholder="At least 8 characters"
+                autocomplete="new-password"
+              />
+            </label>
+          </ngx-control-wrapper>
+
+          <ngx-control-wrapper class="form-field">
+            <label class="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="acceptTerms"
+                name="acceptTerms"
+                [ngModel]="formValue().acceptTerms"
+              />
+              <span class="label-text">I accept the terms of service</span>
+            </label>
+          </ngx-control-wrapper>
+
+          <div class="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              (click)="reset()"
+            >
+              Reset
+            </button>
+            <button
+              type="submit"
+              class="btn btn-primary"
+              [disabled]="state() === 'submitting'"
+            >
+              @if (state() === 'submitting') {
+                Creating account…
+              } @else {
+                Create account
+              }
+            </button>
+          </div>
+        </form>
+      </ngx-card>
+    </div>
+  </ngx-form-page-layout>
+</div>

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.html
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.html
@@ -33,22 +33,37 @@
         <ul
           class="mt-4 space-y-2 text-sm text-gray-600 dark:text-gray-300"
         >
-          <li>(a) Field errors appear on blur — pure Vest suite.</li>
+          <li>
+            (a) Field rules are plain Vest, while this demo intentionally keeps
+            error visibility submit-gated.
+          </li>
           <li>(b) Submitting invalid focuses the first bad field.</li>
           <li>(c) Server failures surface in an alert with Retry.</li>
           <li>(d) Success shows the new account id + Create another.</li>
         </ul>
       </ngx-card>
 
-      <ngx-form-state-card
-        [formState]="formState()"
-        [warnings]="warnings()"
-        [validatedFields]="validatedFields()"
-        [pending]="pending()"
-      />
+      <ngx-form-state-card [feedback]="feedback()" />
     </div>
 
     <div layout-main>
+      @if (showClearSubmitCycle()) {
+        <ngx-alert-panel tone="info" title="Submit cycle active">
+          <p>
+            The form is still in a submitted state, so submit-gated errors stay
+            visible. Clear the submit cycle to return to editing without
+            resetting values, touched state, or dirty state.
+          </p>
+          <button
+            type="button"
+            class="btn btn-secondary mt-3"
+            (click)="clearSubmitCycle()"
+          >
+            Clear submitted state
+          </button>
+        </ngx-alert-panel>
+      }
+
       @if (state() === 'success') {
         <ngx-alert-panel tone="success" title="Account created">
           <p>
@@ -81,96 +96,16 @@
 
       <ngx-card
         title="Create account"
-        subtitle="All fields are required. Submit while invalid to see focus jump to the first error."
+        subtitle="All fields are required. This demo uses a form-scoped submit-gated error display default so you can inspect clearSubmittedState() after an invalid submit."
       >
-        <form
-          ngxVestForm
-          #vestForm="ngxVestForm"
-          [suite]="suite"
+        <ngx-submission-patterns-form-body
           [formValue]="formValue()"
+          [suite]="suite"
+          [submitting]="state() === 'submitting'"
           (formValueChange)="formValue.set($event)"
-          (ngSubmit)="onSubmit()"
-          class="space-y-6"
-        >
-          <ngx-control-wrapper class="form-field">
-            <label>
-              <span class="label-text">Full name</span>
-              <input
-                class="input-field"
-                type="text"
-                id="fullName"
-                name="fullName"
-                [ngModel]="formValue().fullName"
-                placeholder="Ada Lovelace"
-                autocomplete="name"
-              />
-            </label>
-          </ngx-control-wrapper>
-
-          <ngx-control-wrapper class="form-field">
-            <label>
-              <span class="label-text">Email</span>
-              <input
-                class="input-field"
-                type="email"
-                id="email"
-                name="email"
-                [ngModel]="formValue().email"
-                placeholder="ada@example.com"
-                autocomplete="email"
-                inputmode="email"
-              />
-            </label>
-          </ngx-control-wrapper>
-
-          <ngx-control-wrapper class="form-field">
-            <label>
-              <span class="label-text">Password</span>
-              <input
-                class="input-field"
-                type="password"
-                id="password"
-                name="password"
-                [ngModel]="formValue().password"
-                placeholder="At least 8 characters"
-                autocomplete="new-password"
-              />
-            </label>
-          </ngx-control-wrapper>
-
-          <ngx-control-wrapper class="form-field">
-            <label class="flex items-center gap-2">
-              <input
-                type="checkbox"
-                id="acceptTerms"
-                name="acceptTerms"
-                [ngModel]="formValue().acceptTerms"
-              />
-              <span class="label-text">I accept the terms of service</span>
-            </label>
-          </ngx-control-wrapper>
-
-          <div class="flex justify-end gap-3 pt-2">
-            <button
-              type="button"
-              class="btn btn-secondary"
-              (click)="reset()"
-            >
-              Reset
-            </button>
-            <button
-              type="submit"
-              class="btn btn-primary"
-              [disabled]="state() === 'submitting'"
-            >
-              @if (state() === 'submitting') {
-                Creating account…
-              } @else {
-                Create account
-              }
-            </button>
-          </div>
-        </form>
+          (submitted)="onSubmit()"
+          (resetRequested)="reset()"
+        />
       </ngx-card>
     </div>
   </ngx-form-page-layout>

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.ts
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.ts
@@ -1,6 +1,7 @@
 import {
   afterNextRender,
   ChangeDetectionStrategy,
+  computed,
   Component,
   DestroyRef,
   inject,
@@ -11,15 +12,11 @@ import {
 import { HttpErrorResponse } from '@angular/common/http';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
-  createFormFeedbackSignals,
-  FormDirective,
-  NgxVestForms,
-  provideFormContract,
+  createEmptyFormState,
 } from 'ngx-vest-forms';
 import { catchError, EMPTY, finalize } from 'rxjs';
 import {
   SubmissionPatternsModel,
-  submissionPatternsShape,
 } from '../../models/submission-patterns.model';
 import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
 import { Card } from '../../ui/card/card.component';
@@ -29,6 +26,7 @@ import { FormStateCardComponent } from '../../ui/form-state/form-state.component
 import { PageTitle } from '../../ui/page-title/page-title.component';
 import { AccountService } from './account.service';
 import { submissionPatternsContent } from './submission-patterns.content';
+import { SubmissionPatternsFormBody } from './submission-patterns.form';
 import { submissionPatternsSuite } from './submission-patterns.validations';
 
 /** Deterministic outcomes the demo can force through the mock API. */
@@ -51,16 +49,15 @@ type SubmissionState = 'editing' | 'submitting' | 'server-error' | 'success';
 @Component({
   selector: 'ngx-submission-patterns-page',
   imports: [
-    NgxVestForms,
     PageTitle,
     Card,
     AlertPanel,
     FormPageLayout,
     FormStateCardComponent,
     ExampleCardsComponent,
+    SubmissionPatternsFormBody,
   ],
   templateUrl: './submission-patterns.page.html',
-  providers: [provideFormContract(submissionPatternsShape)],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SubmissionPatternsPageComponent {
@@ -78,7 +75,7 @@ export class SubmissionPatternsPageComponent {
   protected readonly state = signal<SubmissionState>('editing');
   protected readonly serverError = signal<string | null>(null);
   protected readonly createdId = signal<string | null>(null);
-
+  protected readonly submitCycleActive = signal(false);
   protected readonly scenarios: ReadonlyArray<{
     label: string;
     value: Scenario;
@@ -90,34 +87,33 @@ export class SubmissionPatternsPageComponent {
   ];
   protected readonly scenario = signal<Scenario>('normal');
 
-  private readonly vestForm =
-    viewChild<FormDirective<SubmissionPatternsModel>>('vestForm');
-  private readonly feedback = createFormFeedbackSignals(this.vestForm);
+  private readonly formBody = viewChild(SubmissionPatternsFormBody);
 
-  protected readonly formState = this.feedback.formState;
-  protected readonly warnings = this.feedback.warnings;
-  protected readonly validatedFields = this.feedback.validatedFields;
-  protected readonly pending = this.feedback.pending;
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
 
+  protected readonly showClearSubmitCycle = computed(
+    () => this.state() === 'editing' && this.submitCycleActive()
+  );
   protected onScenarioChange(value: string): void {
     this.scenario.set(this.isScenario(value) ? value : 'normal');
   }
 
   protected onSubmit(): void {
-    const formDirective = this.vestForm();
-    if (!formDirective) {
+    if (!this.formBody()) {
       return;
     }
+
+    this.submitCycleActive.set(true);
 
     // (b) Submit-time INVALID handling: never call the server, surface
     // errors, and move focus to the first invalid control. Deferred so the
     // submit-driven validation has flushed before we resolve the target.
     afterNextRender(
       () => {
-        if (!this.formState()?.valid) {
+        if (!this.feedback()?.formState()?.valid) {
           this.state.set('editing');
           this.serverError.set(null);
-          formDirective.focusFirstInvalidControl();
+          this.formBody()?.focusFirstInvalidControl();
           return;
         }
 
@@ -149,6 +145,8 @@ export class SubmissionPatternsPageComponent {
       .createAccount(value, errorScenario ? { errorScenario } : undefined)
       .pipe(
         catchError((error: unknown) => {
+          this.formBody()?.clearSubmittedState();
+          this.submitCycleActive.set(false);
           this.state.set('server-error');
           this.serverError.set(this.toErrorMessage(error));
           return EMPTY;
@@ -163,6 +161,8 @@ export class SubmissionPatternsPageComponent {
       )
       .subscribe((result) => {
         this.createdId.set(result.id);
+        this.formBody()?.clearSubmittedState();
+        this.submitCycleActive.set(false);
         this.state.set('success');
       });
   }
@@ -172,12 +172,19 @@ export class SubmissionPatternsPageComponent {
     this.callServer();
   }
 
+  /** End the current submit cycle while preserving values and control metadata. */
+  protected clearSubmitCycle(): void {
+    this.formBody()?.clearSubmittedState();
+    this.submitCycleActive.set(false);
+  }
+
   /** Create another: reset cleanly back to the editing state. */
   protected reset(): void {
     this.state.set('editing');
     this.serverError.set(null);
     this.createdId.set(null);
-    this.vestForm()?.resetForm({});
+    this.submitCycleActive.set(false);
+    this.formBody()?.resetFormState({});
     this.formValue.set({});
   }
 

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.ts
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.ts
@@ -1,0 +1,204 @@
+import {
+  afterNextRender,
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  Injector,
+  signal,
+  viewChild,
+} from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  createFormFeedbackSignals,
+  FormDirective,
+  NgxVestForms,
+  provideFormContract,
+} from 'ngx-vest-forms';
+import { catchError, EMPTY, finalize } from 'rxjs';
+import {
+  SubmissionPatternsModel,
+  submissionPatternsShape,
+} from '../../models/submission-patterns.model';
+import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
+import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
+import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
+import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { PageTitle } from '../../ui/page-title/page-title.component';
+import { AccountService } from './account.service';
+import { submissionPatternsContent } from './submission-patterns.content';
+import { submissionPatternsSuite } from './submission-patterns.validations';
+
+/** Deterministic outcomes the demo can force through the mock API. */
+type Scenario = 'normal' | 'email-taken' | 'server-error' | 'network-error';
+
+/** The four distinct submission concerns, modelled as one page state. */
+type SubmissionState = 'editing' | 'submitting' | 'server-error' | 'success';
+
+/**
+ * Submission Patterns — models the FOUR submission concerns distinctly:
+ *
+ * (a) field validation — the plain Vest suite;
+ * (b) submit-time INVALID handling — never calls the server and moves focus
+ *     to the first invalid control via `FormDirective.focusFirstInvalidControl()`;
+ * (c) server FAILURE messaging — an assertive error panel + Retry;
+ * (d) SUCCESS state — a polite success panel + "Create another".
+ *
+ * ngx-vest-forms public API only.
+ */
+@Component({
+  selector: 'ngx-submission-patterns-page',
+  imports: [
+    NgxVestForms,
+    PageTitle,
+    Card,
+    AlertPanel,
+    FormPageLayout,
+    FormStateCardComponent,
+    ExampleCardsComponent,
+  ],
+  templateUrl: './submission-patterns.page.html',
+  providers: [provideFormContract(submissionPatternsShape)],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SubmissionPatternsPageComponent {
+  private readonly accountService = inject(AccountService);
+  private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly exampleContent = submissionPatternsContent;
+  protected readonly suite = submissionPatternsSuite;
+
+  /** The form value is the single source of truth, owned by the page. */
+  protected readonly formValue = signal<SubmissionPatternsModel>({});
+
+  /** The four-state machine keeping the submission concerns distinct. */
+  protected readonly state = signal<SubmissionState>('editing');
+  protected readonly serverError = signal<string | null>(null);
+  protected readonly createdId = signal<string | null>(null);
+
+  protected readonly scenarios: ReadonlyArray<{
+    label: string;
+    value: Scenario;
+  }> = [
+    { label: 'Normal — succeeds (201)', value: 'normal' },
+    { label: 'Email already taken (409)', value: 'email-taken' },
+    { label: 'Server error (500)', value: 'server-error' },
+    { label: 'Network error', value: 'network-error' },
+  ];
+  protected readonly scenario = signal<Scenario>('normal');
+
+  private readonly vestForm =
+    viewChild<FormDirective<SubmissionPatternsModel>>('vestForm');
+  private readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+  protected readonly formState = this.feedback.formState;
+  protected readonly warnings = this.feedback.warnings;
+  protected readonly validatedFields = this.feedback.validatedFields;
+  protected readonly pending = this.feedback.pending;
+
+  protected onScenarioChange(value: string): void {
+    this.scenario.set(this.isScenario(value) ? value : 'normal');
+  }
+
+  protected onSubmit(): void {
+    const formDirective = this.vestForm();
+    if (!formDirective) {
+      return;
+    }
+
+    // (b) Submit-time INVALID handling: never call the server, surface
+    // errors, and move focus to the first invalid control. Deferred so the
+    // submit-driven validation has flushed before we resolve the target.
+    afterNextRender(
+      () => {
+        if (!this.formState()?.valid) {
+          this.state.set('editing');
+          this.serverError.set(null);
+          formDirective.focusFirstInvalidControl();
+          return;
+        }
+
+        this.callServer();
+      },
+      { injector: this.injector }
+    );
+  }
+
+  /** (c)/(d) — the only place the server is contacted. */
+  private callServer(): void {
+    this.state.set('submitting');
+    this.serverError.set(null);
+
+    const scenario = this.scenario();
+    const value = structuredClone(this.formValue());
+    if (scenario === 'email-taken') {
+      // The mock returns 409 when the email contains "taken".
+      value.email = 'taken@example.com';
+    }
+    const errorScenario =
+      scenario === 'server-error'
+        ? 'server-error'
+        : scenario === 'network-error'
+          ? 'network-error'
+          : undefined;
+
+    this.accountService
+      .createAccount(value, errorScenario ? { errorScenario } : undefined)
+      .pipe(
+        catchError((error: unknown) => {
+          this.state.set('server-error');
+          this.serverError.set(this.toErrorMessage(error));
+          return EMPTY;
+        }),
+        finalize(() => {
+          if (this.state() === 'submitting') {
+            // Defensive: should not happen, success/error always set state.
+            this.state.set('editing');
+          }
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((result) => {
+        this.createdId.set(result.id);
+        this.state.set('success');
+      });
+  }
+
+  /** Retry re-submits the exact same value through the same path. */
+  protected retry(): void {
+    this.callServer();
+  }
+
+  /** Create another: reset cleanly back to the editing state. */
+  protected reset(): void {
+    this.state.set('editing');
+    this.serverError.set(null);
+    this.createdId.set(null);
+    this.vestForm()?.resetForm({});
+    this.formValue.set({});
+  }
+
+  private isScenario(value: string): value is Scenario {
+    return this.scenarios.some((scenario) => scenario.value === value);
+  }
+
+  private toErrorMessage(error: unknown): string {
+    if (error instanceof HttpErrorResponse) {
+      const body = error.error as { message?: string } | null;
+      if (body?.message) {
+        return body.message;
+      }
+      if (error.status === 0) {
+        return 'Network error — could not reach the server. Check your connection and retry.';
+      }
+      return `Request failed (${error.status} ${error.statusText}).`;
+    }
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return 'Something went wrong while creating the account.';
+  }
+}

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.validations.ts
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.validations.ts
@@ -1,0 +1,56 @@
+import { type NgxVestSuite } from 'ngx-vest-forms';
+import { create, enforce, omitWhen, test, warn } from 'vest';
+import { SubmissionPatternsModel } from '../../models/submission-patterns.model';
+
+/**
+ * Plain Vest suite for the account-creation form. It has no Angular
+ * dependency and is unit-testable in isolation:
+ * `submissionPatternsSuite({ email: 'x' })`.
+ *
+ * This is concern (a): pure FIELD validation. It is deliberately unaware of
+ * the server — submit-time invalid handling, server failure messaging, and
+ * the success state all live in the page, not here.
+ */
+export const submissionPatternsSuite: NgxVestSuite<SubmissionPatternsModel> =
+  create((model: SubmissionPatternsModel) => {
+    test('fullName', 'Full name is required', () => {
+      enforce(model.fullName).isNotBlank();
+    });
+
+    test('email', 'Email is required', () => {
+      enforce(model.email).isNotBlank();
+    });
+
+    omitWhen(!model.email, () => {
+      test('email', 'Enter a valid email address', () => {
+        enforce(model.email ?? '').matches(
+          /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
+        );
+      });
+    });
+
+    test('password', 'Password is required', () => {
+      enforce(model.password).isNotBlank();
+    });
+
+    omitWhen(!model.password, () => {
+      test('password', 'Password must be at least 8 characters', () => {
+        enforce(model.password ?? '').longerThanOrEquals(8);
+      });
+
+      // Advisory, non-blocking guidance: an 8–11 char password is allowed
+      // but nudged toward something stronger.
+      test(
+        'password',
+        'Consider using 12+ characters for a stronger password',
+        () => {
+          warn();
+          enforce(model.password ?? '').longerThanOrEquals(12);
+        }
+      );
+    });
+
+    test('acceptTerms', 'You must accept the terms', () => {
+      enforce(model.acceptTerms).isTruthy();
+    });
+  });

--- a/apps/examples/src/app/pages/validation-config-demo/README.md
+++ b/apps/examples/src/app/pages/validation-config-demo/README.md
@@ -1,0 +1,59 @@
+# Validation Config Demo
+
+A focused look at `createValidationConfig()` — the single map that tells
+ngx-vest-forms which fields depend on which, so a change to one field
+revalidates the others without manual subscriptions.
+
+## Why it exists
+
+Cross-field validation is easy to get subtly wrong: you update a password and
+the confirm field keeps its stale error, or a conditional field never
+re-validates after a toggle. This demo isolates the dependency-config concept
+and shows every flavour of relationship in one form.
+
+## What it does
+
+Builds one `validationConfig` covering five relationships:
+
+- `password` ↔ `confirmPassword` (bidirectional)
+- `quantity` ↔ `quantityJustification` (bidirectional)
+- `startDate` ↔ `endDate` (bidirectional)
+- `requiresJustification` → `justification` (one-way `whenChanged`)
+- `country` → `[state, zipCode]` (one-way `whenChanged`, fan-out)
+
+The Vest suite backs these with `omitWhen`-gated rules: confirm-password and
+match checks only run when a password exists, justification is required only
+when the toggle is on, state/postal code only when a country is chosen, and the
+"end date after start date" rule only when both dates are set. A non-blocking
+`warn()` recommends 12+ character passwords.
+
+The page splits feedback into **errors**, **info** (date-range messages routed
+separately), **warnings**, **validated fields**, and **pending**.
+
+## ngx-vest-forms APIs showcased
+
+- `createValidationConfig()` with `.bidirectional()` and `.whenChanged()`
+  (including a fan-out to multiple dependents)
+- `NgxVestForms`, `FormDirective`, `provideFormContract`
+- `createFormFeedbackSignals()` for `formState`, `warnings`,
+  `validatedFields`, `pending`
+- `FormDirective.resetForm()`
+- `NgxVestSuite` / Vest `create`, `test`, `enforce`, `omitWhen`, `warn`
+
+## Key files
+
+- `validation-config-demo.page.ts` / `.html` — page shell and the
+  `validationConfig` definition, plus error/info partitioning
+- `validation-config-demo.form.ts` / `.html` — the form body component
+- `validation-demo.validations.ts` — the Vest suite
+- `../../models/validation-demo.model.ts` — model and contract
+
+## Behaviour notes
+
+- `whenChanged` is one-directional on purpose: changing `requiresJustification`
+  revalidates `justification`, but typing in `justification` does not re-run the
+  toggle.
+- `country` → `[state, zipCode]` shows a single source fanning out to multiple
+  dependents in one call.
+- Date messages are pulled out of the error stream and shown as info so the
+  range hint reads as guidance rather than a hard failure.

--- a/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.content.ts
+++ b/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.content.ts
@@ -1,0 +1,45 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const validationConfigDemoContent = defineExampleContent({
+  demonstrates: {
+    icon: '🔗',
+    title: 'What this demonstrates',
+    points: [
+      'A single createValidationConfig() map declaring every field dependency for the form',
+      'bidirectional() pairs: password ↔ confirmPassword, quantity ↔ quantityJustification, and startDate ↔ endDate',
+      'whenChanged() one-way triggers: requiresJustification → justification, and country → [state, zipCode]',
+      'omitWhen-gated rules that only apply when a dependency is present (conditional justification, location fields, date ordering)',
+      'A non-blocking password strength warning (warn()) shown next to blocking length/match errors',
+      'Date range cross-field rule: end date must be after start date once both are set',
+      'Form-state feedback split into errors, info (date messages), warnings, validated fields, and pending',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'One config map, many dependencies',
+        points: [
+          'Express all cross-field relationships declaratively with .bidirectional() and .whenChanged()',
+          'Let a change to one field automatically revalidate its dependents without manual wiring',
+          'Avoid race conditions and redundant validation passes',
+        ],
+      },
+      {
+        title: 'Conditional fields',
+        points: [
+          'Pair omitWhen in the suite with whenChanged in the config so toggled fields revalidate correctly',
+          'Drive @if-rendered sections (justification, state/zip) from the same model',
+        ],
+      },
+      {
+        title: 'Surfacing feedback',
+        points: [
+          'Separate informational date messages from blocking errors',
+          'Show warn() output independently of errors',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Display modes', route: 'display-modes-demo' },
+  },
+});

--- a/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.form.html
+++ b/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.form.html
@@ -53,7 +53,7 @@
       description="This pair uses on-blur wrappers so dependent errors wait for the target field's own blur."
     >
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
-        <ngx-control-wrapper class="form-field" [errorDisplayMode]="'on-blur'">
+        <ngx-control-wrapper class="form-field" errorDisplayMode="on-blur">
           <label>
             <span class="label-text">Quantity</span>
             <input
@@ -68,7 +68,7 @@
           </label>
         </ngx-control-wrapper>
 
-        <ngx-control-wrapper class="form-field" [errorDisplayMode]="'on-blur'">
+        <ngx-control-wrapper class="form-field" errorDisplayMode="on-blur">
           <label>
             <span class="label-text">Justification</span>
             <textarea

--- a/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.form.ts
+++ b/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.form.ts
@@ -39,20 +39,16 @@ export class ValidationConfigDemoFormBody {
 
   private readonly vestForm =
     viewChild<FormDirective<ValidationDemoModel>>('vestForm');
-  private readonly formFeedback = createFormFeedbackSignals(this.vestForm);
+  readonly feedback = createFormFeedbackSignals(this.vestForm);
 
   /** Exposes the directive's packaged form state with up-to-date errors. */
-  readonly formState = this.formFeedback.formState;
-
+  
   /** Exposes field warnings as a plain Record for presentational components. */
-  readonly warnings = this.formFeedback.warnings;
-
+  
   /** Field paths that have been validated (touched/blurred or submitted). */
-  readonly validatedFields = this.formFeedback.validatedFields;
-
+  
   /** True while async validation is in progress. */
-  readonly pending = this.formFeedback.pending;
-
+  
   protected onSubmit(): void {
     this.submitted.emit();
   }

--- a/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.form.ts
+++ b/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.form.ts
@@ -41,14 +41,6 @@ export class ValidationConfigDemoFormBody {
     viewChild<FormDirective<ValidationDemoModel>>('vestForm');
   readonly feedback = createFormFeedbackSignals(this.vestForm);
 
-  /** Exposes the directive's packaged form state with up-to-date errors. */
-  
-  /** Exposes field warnings as a plain Record for presentational components. */
-  
-  /** Field paths that have been validated (touched/blurred or submitted). */
-  
-  /** True while async validation is in progress. */
-  
   protected onSubmit(): void {
     this.submitted.emit();
   }

--- a/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.page.html
+++ b/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.page.html
@@ -28,13 +28,10 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="formBody.formState()"
+        [feedback]="formBody.feedback"
         [errors]="formErrors()"
-        [warnings]="formBody.warnings()"
         [info]="formInfo()"
-        [validatedFields]="formBody.validatedFields()"
-        [pending]="formBody.pending()"
-      />
+        />
     </div>
 
     <div layout-main>

--- a/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.page.html
+++ b/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.page.html
@@ -4,6 +4,8 @@
     subtitle="Explore dependency-aware revalidation patterns with a single configuration map."
   />
 
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
   <ngx-form-page-layout>
     <div layout-aside class="sidebar-card-stack">
       <ngx-card title="Key Features">

--- a/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.page.ts
+++ b/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.page.ts
@@ -31,6 +31,7 @@ import { validationDemoSuite } from './validation-demo.validations';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ValidationConfigDemoPageComponent {
+  protected readonly feedback = computed(() => this.formBody()?.feedback);
   private readonly initialFormValue: ValidationDemoModel = {
     requiresJustification: false,
   };
@@ -55,7 +56,7 @@ export class ValidationConfigDemoPageComponent {
       .build();
 
   protected readonly formInfo = computed(() =>
-    this.#getMessagesByFields(this.formBody()?.formState()?.errors ?? {}, [
+    this.#getMessagesByFields(this.feedback()?.formState()?.errors ?? {}, [
       'startDate',
       'endDate',
     ])
@@ -63,13 +64,13 @@ export class ValidationConfigDemoPageComponent {
 
   protected readonly formErrors = computed(() =>
     this.#getMessagesExcludingFields(
-      this.formBody()?.formState()?.errors ?? {},
+      this.feedback()?.formState()?.errors ?? {},
       ['startDate', 'endDate']
     )
   );
 
   protected save(): void {
-    if (this.formBody()?.formState()?.valid) {
+    if (this.feedback()?.formState()?.valid) {
       // Intentionally no console output or alerts in examples to keep CI and demos quiet
     }
   }

--- a/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.page.ts
+++ b/apps/examples/src/app/pages/validation-config-demo/validation-config-demo.page.ts
@@ -10,7 +10,9 @@ import { ValidationDemoModel } from '../../models/validation-demo.model';
 import { Card } from '../../ui/card/card.component';
 import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
+import { validationConfigDemoContent } from './validation-config-demo.content';
 import { ValidationConfigDemoFormBody } from './validation-config-demo.form';
 import { validationDemoSuite } from './validation-demo.validations';
 
@@ -22,6 +24,7 @@ import { validationDemoSuite } from './validation-demo.validations';
     FormStateCardComponent,
     PageTitle,
     ValidationConfigDemoFormBody,
+    ExampleCardsComponent,
   ],
   templateUrl: './validation-config-demo.page.html',
   styleUrls: ['./validation-config-demo.page.scss'],
@@ -37,6 +40,8 @@ export class ValidationConfigDemoPageComponent {
   );
 
   private readonly formBody = viewChild(ValidationConfigDemoFormBody);
+
+  protected readonly exampleContent = validationConfigDemoContent;
 
   protected readonly suite = validationDemoSuite;
 

--- a/apps/examples/src/app/pages/wizard-form/README.md
+++ b/apps/examples/src/app/pages/wizard-form/README.md
@@ -1,0 +1,60 @@
+# Multi-Form Wizard
+
+Run three coordinated forms with per-step validation and one final submission
+flow.
+
+## Why this demo exists
+
+Multi-step registration and checkout flows are a common requirement, and they
+raise two hard questions: how do you validate each step independently while
+still treating the whole thing as one submission, and how do you keep entered
+data and validity intact as the user moves back and forth? This demo answers
+both with `ngx-vest-forms`, using one Vest suite and one model per step plus a
+parent page that orchestrates navigation, validity, and the final submit.
+
+## What it does
+
+- Three steps — **Account**, **Profile**, **Review** — each rendered by its own
+  form component (`wizard-step1/2/3.form.ts`) with its own suite and model.
+- `Next` validates only the current step. If valid it advances; if not, focus
+  moves to the step's first invalid control.
+- The final submit calls `submitAll()`, which re-validates every step, and on
+  failure jumps to and focuses the first invalid step.
+- Step 1 demonstrates bidirectional confirmation validation (email and
+  password). Step 2 demonstrates conditional validation (newsletter frequency
+  required only when subscribed), with the validation config rebuilt inside a
+  `computed()`. Step 3 demonstrates an `optional()` comments field.
+- Step data and per-step validity live in page-level signals, so navigating
+  back never discards what the user entered.
+- Sidebar status badges reflect per-step validity and overall readiness.
+
+## ngx-vest-forms APIs showcased
+
+- `createValidationConfig<T>()` with `.bidirectional()` (Step 1) and
+  `.whenChanged()` rebuilt reactively (Step 2).
+- Per-step form components exposing `isValid()`, `validatedFields()`,
+  `pending()`, `markAllAsTouched()`, and `focusFirstInvalidControl()`.
+- `NgxFirstInvalidOptions` to customize scroll/focus on Step 2's invalid
+  submit.
+- Vest `optional()` so a blank `comments` field does not block validity but
+  is still validated when filled.
+
+## Key files
+
+- `wizard-form.page.ts` — step state, validity signals, navigation, final
+  submit, focus orchestration.
+- `wizard.form.ts` / `wizard.form.html` — body that switches the active step
+  component and forwards step APIs to the page.
+- `wizard-step1.form.ts`, `wizard-step2.form.ts`, `wizard-step3.form.ts` —
+  individual step forms.
+- `wizard.validations.ts` — the three Vest suites (bidirectional, conditional,
+  optional).
+- `wizard-form.content.ts` — in-app "What this demonstrates / learn" cards.
+
+## Behavior notes
+
+- Advancing requires the current step to be valid; the final submit re-checks
+  all steps regardless of how the user navigated.
+- Validity and entered data persist across step navigation by design.
+- Focus management deliberately differs on Step 2 to show
+  `NgxFirstInvalidOptions` in use.

--- a/apps/examples/src/app/pages/wizard-form/wizard-form.content.ts
+++ b/apps/examples/src/app/pages/wizard-form/wizard-form.content.ts
@@ -1,0 +1,49 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const wizardContent = defineExampleContent({
+  demonstrates: {
+    icon: '🧭',
+    title: 'What this demonstrates',
+    points: [
+      'Three independent forms (Account, Profile, Review) each with their own Vest suite and model, coordinated by one page.',
+      'Per-step validation gates navigation: a step must be valid before Next advances.',
+      'A single final submit re-checks every step together and routes the user to the first invalid step.',
+      'Step 1 bidirectional validation: email ↔ confirmEmail and password ↔ confirmPassword.',
+      'Step 2 conditional validation: newsletterFrequency is only required when subscribeNewsletter is on (config rebuilt reactively via computed).',
+      'Step 3 optional field: comments is optional() but must pass length validation when provided.',
+      'Each step exposes isValid()/validatedFields()/pending() so the parent can drive navigation and focus.',
+      'Invalid-submit focus management, including custom NgxFirstInvalidOptions on Step 2.',
+      'Step data and validity persist while navigating back and forth.',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'Coordinating multiple forms',
+        points: [
+          'Keep one suite + model per step and lift validity/error signals to the page.',
+          'Compute overall readiness (allFormsValid) from per-step validity signals.',
+          'Persist step state in the parent so navigation never loses entered data.',
+        ],
+      },
+      {
+        title: 'Step validation patterns',
+        points: [
+          'Use createValidationConfig with bidirectional() for confirmation fields.',
+          'Rebuild a validation config inside a computed() for conditional dependencies.',
+          'Use Vest optional() so a blank optional field does not block isValid().',
+        ],
+      },
+      {
+        title: 'Submission & focus flow',
+        points: [
+          'Validate the current step on Next, the whole wizard on final submit.',
+          'Route to the first invalid step and focus its first invalid control.',
+          'Pass NgxFirstInvalidOptions to tune scroll/focus behavior per step.',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Purchase checkout', route: 'purchase' },
+  },
+});

--- a/apps/examples/src/app/pages/wizard-form/wizard-form.page.html
+++ b/apps/examples/src/app/pages/wizard-form/wizard-form.page.html
@@ -4,6 +4,8 @@
     subtitle="Run three coordinated forms with per-step validation and one final submission flow."
   />
 
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
   <ngx-form-page-layout>
     <aside layout-aside class="sidebar-card-stack">
       <ngx-card title="Wizard State">

--- a/apps/examples/src/app/pages/wizard-form/wizard-form.page.ts
+++ b/apps/examples/src/app/pages/wizard-form/wizard-form.page.ts
@@ -16,11 +16,13 @@ import {
 } from '../../models/wizard-form.model';
 import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
 import { Card } from '../../ui/card/card.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
 import { StatusBadge } from '../../ui/status-badge/status-badge.component';
 import { WizardStepConfig, WizardStepsComponent } from '../../ui/wizard';
+import { wizardContent } from './wizard-form.content';
 import { WizardFormBodyComponent } from './wizard.form';
 import {
   wizardStep1Suite,
@@ -37,6 +39,7 @@ import {
     AlertPanel,
     PageTitle,
     StatusBadge,
+    ExampleCardsComponent,
     WizardStepsComponent,
     WizardFormBodyComponent,
   ],
@@ -46,6 +49,7 @@ import {
 })
 export class WizardFormPageComponent {
   private readonly injector = inject(Injector);
+  protected readonly exampleContent = wizardContent;
   protected readonly currentStep = signal(1);
 
   protected readonly steps: WizardStepConfig[] = [

--- a/apps/examples/src/app/pages/zod-schema-demo/README.md
+++ b/apps/examples/src/app/pages/zod-schema-demo/README.md
@@ -1,0 +1,49 @@
+# Zod Schema Demo
+
+Route: `zod-schema-demo` · Title: "Zod Schema Demo"
+
+## What & why
+
+This page demonstrates pairing an **external Zod schema** with a Vest suite for
+the same form model. The Zod `z.object` schema acts as a shared structural /
+type contract, while the Vest `test()` callbacks own the per-field business
+rules that ngx-vest-forms surfaces in the UI.
+
+Vest 6.3.x supports schema-aware `create(..., schema)` suites when the schema is
+built with Vest's native `n4s/enforce` primitives. This example intentionally
+keeps Zod **separate** from `create()` to show how an external schema library
+can still serve as a structural contract alongside Vest-powered field
+validation. For the native approach, see the sibling **Native Vest Schema
+Demo**.
+
+## ngx-vest-forms public APIs showcased
+
+- `provideFormContract(zodSchemaDemoContract)` — registers the shape contract
+  for the form body.
+- `NgxVestForms` — template directives used by the form HTML.
+- `FormDirective<ZodSchemaDemoModel>` — accessed via `viewChild` to read
+  `formState()` and bind `(errorsChange)`.
+- `createFormFeedbackSignals` / `createEmptyFormState` — derive `formState`,
+  `warnings`, `validatedFields`, and `pending` for the sidebar state card.
+- `NgxVestSuite<T>` — typed suite contract.
+
+## Key files
+
+- `zod-schema-demo.validations.ts` — exported `zodFormSchema` (Zod) plus the
+  separate Vest suite `zodSchemaDemoSuite`.
+- `zod-schema-demo.form.ts` / `.form.html` — the form body bound to the suite
+  and contract; tracks errors via the directive's `(errorsChange)` event for
+  more reactive updates.
+- `zod-schema-demo.page.ts` / `.page.html` — page shell, title, sidebar
+  explanation, and form state card.
+- `zod-schema-demo.content.ts` — typed `ExampleContent` rendered by
+  `<ngx-example-cards>`.
+
+## Behavior
+
+The Zod schema (`firstName`, `lastName`, `email`, `age` int 18–120, and a nested
+`address` with a ZIP regex) documents and can validate the structural model
+independently. The Vest suite mirrors those rules with `enforce` and adds
+form-facing messages. During field validation ngx-vest-forms runs
+`suite.only(field).run(model)`, so only the matching `test()` callbacks fire per
+field; the exported Zod schema remains usable for separate structural checks.

--- a/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.content.ts
+++ b/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.content.ts
@@ -1,0 +1,38 @@
+import { defineExampleContent } from '../../shared/example-content';
+
+export const zodSchemaContent = defineExampleContent({
+  demonstrates: {
+    icon: '🔗',
+    title: 'What this demonstrates',
+    points: [
+      'A Zod schema (z.object) kept alongside a Vest suite as an external structural contract for the same form model',
+      'Per-field Vest test() callbacks using enforce for the field-level rules that drive the UI',
+      'The same model covered two ways: Zod for structural/type validation, Vest for the form-facing business messages',
+      'Nested address validation expressed in both the Zod schema and the Vest suite (street, city, ZIP 4–6 digits)',
+      'ngx-vest-forms running focused per-field validation via suite.only(field).run(model)',
+      'A deliberate Vest 6.3.x choice: native create(..., schema) flows use n4s/enforce, so the Zod schema stays separate here',
+      'Live form state, warnings, validated fields, and pending status via createFormFeedbackSignals',
+    ],
+  },
+  learn: {
+    title: "What you'll learn",
+    sections: [
+      {
+        title: 'External schema + Vest',
+        points: [
+          'Keep a Zod z.object schema as a shared structural contract without coupling it into the Vest suite',
+          'Let Vest test() rules own the per-field UI validation while the Zod schema validates shape/types separately',
+          'Understand why Vest 6.3.x prefers n4s/enforce for native create(..., schema) and Zod stays standalone',
+        ],
+      },
+      {
+        title: 'Field vs. full runs',
+        points: [
+          'suite.run(model) executes the whole suite; suite.only(field).run(model) runs only that field’s tests',
+          'ngx-vest-forms uses focused runs for per-field feedback, keeping the Zod schema available for structural checks',
+        ],
+      },
+    ],
+    nextStep: { label: 'Next: Native Vest schema', route: 'native-schema-demo' },
+  },
+});

--- a/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.content.ts
+++ b/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.content.ts
@@ -29,7 +29,7 @@ export const zodSchemaContent = defineExampleContent({
         title: 'Field vs. full runs',
         points: [
           'suite.run(model) executes the whole suite; suite.only(field).run(model) runs only that field’s tests',
-          'ngx-vest-forms uses focused runs for per-field feedback, keeping the Zod schema available for structural checks',
+          'ngx-vest-forms uses focused runs for per-field feedback, with the Zod schema bound directly via [formContract] for structural checks',
         ],
       },
     ],

--- a/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.form.html
+++ b/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.form.html
@@ -3,6 +3,7 @@
     ngxVestForm
     #vestForm="ngxVestForm"
     [suite]="suite()"
+    [formContract]="formContract"
     [formValue]="formValue()"
     (formValueChange)="formValueChange.emit($event)"
     (errorsChange)="currentErrors.set($event)"

--- a/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.form.ts
+++ b/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.form.ts
@@ -13,7 +13,6 @@ import {
   FormDirective,
   NgxVestForms,
   NgxVestSuite,
-  provideFormContract,
 } from 'ngx-vest-forms';
 import {
   ZodSchemaDemoModel,
@@ -26,12 +25,12 @@ import { FormSectionComponent } from '../../ui/form-section/form-section.compone
   selector: 'ngx-zod-schema-demo-form-body',
   imports: [NgxVestForms, Card, FormSectionComponent],
   templateUrl: './zod-schema-demo.form.html',
-  providers: [provideFormContract(zodSchemaDemoContract)],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ZodSchemaDemoFormBody {
   readonly formValue = input.required<ZodSchemaDemoModel>();
   readonly suite = input.required<NgxVestSuite<ZodSchemaDemoModel>>();
+  readonly formContract = zodSchemaDemoContract;
 
   readonly formValueChange = output<ZodSchemaDemoModel>();
   readonly submitted = output();
@@ -46,7 +45,7 @@ export class ZodSchemaDemoFormBody {
    * than formState.errors when the form's overall status stays the same.
    */
   protected readonly currentErrors = signal<Record<string, string[]>>({});
-  private readonly formFeedback = createFormFeedbackSignals(this.vestForm, {
+  readonly feedback = createFormFeedbackSignals(this.vestForm, {
     formState: computed(() => {
       const state = this.vestForm()?.formState();
       if (!state) return createEmptyFormState<ZodSchemaDemoModel>();
@@ -55,17 +54,13 @@ export class ZodSchemaDemoFormBody {
   });
 
   /** Exposes the directive's packaged form state with up-to-date errors. */
-  readonly formState = this.formFeedback.formState;
-
+  
   /** Exposes field warnings as a plain Record for presentational components. */
-  readonly warnings = this.formFeedback.warnings;
-
+  
   /** Field paths that have been validated (touched/blurred or submitted). */
-  readonly validatedFields = this.formFeedback.validatedFields;
-
+  
   /** True while async validation is in progress. */
-  readonly pending = this.formFeedback.pending;
-
+  
   protected onSubmit(): void {
     this.submitted.emit();
   }

--- a/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.form.ts
+++ b/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.form.ts
@@ -53,14 +53,6 @@ export class ZodSchemaDemoFormBody {
     }),
   });
 
-  /** Exposes the directive's packaged form state with up-to-date errors. */
-  
-  /** Exposes field warnings as a plain Record for presentational components. */
-  
-  /** Field paths that have been validated (touched/blurred or submitted). */
-  
-  /** True while async validation is in progress. */
-  
   protected onSubmit(): void {
     this.submitted.emit();
   }

--- a/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.page.html
+++ b/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.page.html
@@ -4,6 +4,8 @@
     subtitle="Combine a Zod schema alongside Vest per-field business rules in one example flow."
   />
 
+  <ngx-example-cards [content]="exampleContent" class="mb-8 block" />
+
   <ngx-form-page-layout>
     <div layout-aside class="sidebar-card-stack">
       <ngx-card title="How Zod + Vest Works">

--- a/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.page.html
+++ b/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.page.html
@@ -42,11 +42,8 @@
       </ngx-card>
 
       <ngx-form-state-card
-        [formState]="formBody.formState()"
-        [warnings]="formBody.warnings()"
-        [validatedFields]="formBody.validatedFields()"
-        [pending]="formBody.pending()"
-      />
+        [feedback]="formBody.feedback"
+        />
     </div>
 
     <div layout-main>

--- a/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.page.ts
+++ b/apps/examples/src/app/pages/zod-schema-demo/zod-schema-demo.page.ts
@@ -3,7 +3,9 @@ import { ZodSchemaDemoModel } from '../../models/zod-schema-demo.model';
 import { Card } from '../../ui/card/card.component';
 import { FormPageLayout } from '../../ui/form-page-layout/form-page-layout.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
+import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { PageTitle } from '../../ui/page-title/page-title.component';
+import { zodSchemaContent } from './zod-schema-demo.content';
 import { ZodSchemaDemoFormBody } from './zod-schema-demo.form';
 import { zodSchemaDemoSuite } from './zod-schema-demo.validations';
 
@@ -11,6 +13,7 @@ import { zodSchemaDemoSuite } from './zod-schema-demo.validations';
   selector: 'ngx-zod-schema-demo-page',
   imports: [
     Card,
+    ExampleCardsComponent,
     FormPageLayout,
     FormStateCardComponent,
     PageTitle,
@@ -24,6 +27,8 @@ export class ZodSchemaDemoPageComponent {
   protected readonly formValue = signal<ZodSchemaDemoModel>({});
 
   protected readonly suite = zodSchemaDemoSuite;
+
+  protected readonly exampleContent = zodSchemaContent;
 
   protected save(): void {
     // Intentionally no console output in examples to keep CI and demos quiet

--- a/apps/examples/src/app/services/mock-people-api.interceptor.ts
+++ b/apps/examples/src/app/services/mock-people-api.interceptor.ts
@@ -18,6 +18,7 @@ type MockPerson = {
 };
 
 const MOCK_RESPONSE_DELAY_MS = 800;
+const MOCK_USERNAME_DELAY_MS = 600;
 
 const MOCK_PEOPLE: Record<string, MockPerson> = {
   '1': {
@@ -27,10 +28,32 @@ const MOCK_PEOPLE: Record<string, MockPerson> = {
   },
 };
 
+/**
+ * Usernames that are already taken in the mock directory. The Async Username
+ * demo validates against `GET /api/username-availability/:name`.
+ */
+const TAKEN_USERNAMES = new Set([
+  'admin',
+  'root',
+  'support',
+  'ada',
+  'luke',
+  'taken',
+  'test',
+]);
+
 function getPersonId(url: string): string | null {
   const requestUrl = new URL(url, globalThis.location.origin);
   const match = requestUrl.pathname.match(/^\/api\/people\/([^/]+)$/);
   return match?.[1] ?? null;
+}
+
+function getUsername(url: string): string | null {
+  const requestUrl = new URL(url, globalThis.location.origin);
+  const match = requestUrl.pathname.match(
+    /^\/api\/username-availability\/([^/]+)$/
+  );
+  return match?.[1] ? decodeURIComponent(match[1]) : null;
 }
 
 function getErrorScenario(url: string): MockErrorScenario | null {
@@ -51,7 +74,7 @@ function getErrorScenario(url: string): MockErrorScenario | null {
 
 function createErrorResponse(
   requestUrl: string,
-  personId: string,
+  detail: string,
   errorScenario: MockErrorScenario
 ): HttpErrorResponse {
   switch (errorScenario) {
@@ -60,18 +83,14 @@ function createErrorResponse(
         url: requestUrl,
         status: 401,
         statusText: 'Unauthorized',
-        error: {
-          message: `You are not authorized to load mock person ${personId}`,
-        },
+        error: { message: `You are not authorized: ${detail}` },
       });
     case 'server-error':
       return new HttpErrorResponse({
         url: requestUrl,
         status: 500,
         statusText: 'Internal Server Error',
-        error: {
-          message: `Mock server failed while loading person ${personId}`,
-        },
+        error: { message: `Mock server failed: ${detail}` },
       });
     case 'network-error':
       return new HttpErrorResponse({
@@ -79,8 +98,7 @@ function createErrorResponse(
         status: 0,
         statusText: 'Unknown Error',
         error: {
-          message:
-            'Simulated network outage while contacting the mock people API',
+          message: `Simulated network outage while contacting the mock API (${detail})`,
         },
       });
     case 'not-found':
@@ -89,14 +107,91 @@ function createErrorResponse(
         url: requestUrl,
         status: 404,
         statusText: 'Not Found',
-        error: {
-          message: `Mock person ${personId} not found`,
-        },
+        error: { message: `Not found: ${detail}` },
       });
   }
 }
 
+/**
+ * In-app mock API used by several demos. Self-contained — no backend service.
+ *
+ * Routes:
+ * - `GET  /api/people/:id`                     → person record (Purchase demo)
+ * - `GET  /api/username-availability/:name`    → `{ username, available }`
+ * - `POST /api/account`                        → `{ id }` or a server error
+ *
+ * Any route accepts `?errorScenario=not-found|unauthorized|server-error|network-error`
+ * to deterministically simulate failures.
+ */
 export const mockPeopleApiInterceptor: HttpInterceptorFn = (request, next) => {
+  // ── GET /api/username-availability/:name ────────────────────────────────
+  if (request.method === 'GET') {
+    const username = getUsername(request.url);
+    if (username !== null) {
+      const errorScenario = getErrorScenario(request.url);
+      if (errorScenario) {
+        return of(null).pipe(
+          delay(MOCK_USERNAME_DELAY_MS),
+          mergeMap(() =>
+            throwError(() =>
+              createErrorResponse(request.url, username, errorScenario)
+            )
+          )
+        );
+      }
+      const available = !TAKEN_USERNAMES.has(username.trim().toLowerCase());
+      return of(
+        new HttpResponse<{ username: string; available: boolean }>({
+          status: 200,
+          body: { username, available },
+        })
+      ).pipe(delay(MOCK_USERNAME_DELAY_MS));
+    }
+  }
+
+  // ── POST /api/account ───────────────────────────────────────────────────
+  if (request.method === 'POST') {
+    const requestUrl = new URL(request.url, globalThis.location.origin);
+    if (requestUrl.pathname === '/api/account') {
+      const errorScenario = getErrorScenario(request.url);
+      const body = (request.body ?? {}) as { email?: string };
+      // A deterministic "server-side" failure the demo can trigger on demand.
+      if (errorScenario) {
+        return of(null).pipe(
+          delay(MOCK_RESPONSE_DELAY_MS),
+          mergeMap(() =>
+            throwError(() =>
+              createErrorResponse(request.url, 'account creation', errorScenario)
+            )
+          )
+        );
+      }
+      if ((body.email ?? '').toLowerCase().includes('taken')) {
+        return of(null).pipe(
+          delay(MOCK_RESPONSE_DELAY_MS),
+          mergeMap(() =>
+            throwError(
+              () =>
+                new HttpErrorResponse({
+                  url: request.url,
+                  status: 409,
+                  statusText: 'Conflict',
+                  error: { message: 'An account with that email already exists.' },
+                })
+            )
+          )
+        );
+      }
+      return of(
+        new HttpResponse<{ id: string }>({
+          status: 201,
+          body: { id: `acct_${Date.now()}` },
+        })
+      ).pipe(delay(MOCK_RESPONSE_DELAY_MS));
+    }
+  }
+
+  // ── GET /api/people/:id ─────────────────────────────────────────────────
   if (request.method !== 'GET') {
     return next(request);
   }
@@ -112,7 +207,7 @@ export const mockPeopleApiInterceptor: HttpInterceptorFn = (request, next) => {
       delay(MOCK_RESPONSE_DELAY_MS),
       mergeMap(() =>
         throwError(() =>
-          createErrorResponse(request.url, personId, errorScenario)
+          createErrorResponse(request.url, `person ${personId}`, errorScenario)
         )
       )
     );
@@ -124,7 +219,7 @@ export const mockPeopleApiInterceptor: HttpInterceptorFn = (request, next) => {
       delay(MOCK_RESPONSE_DELAY_MS),
       mergeMap(() =>
         throwError(() =>
-          createErrorResponse(request.url, personId, 'not-found')
+          createErrorResponse(request.url, `person ${personId}`, 'not-found')
         )
       )
     );

--- a/apps/examples/src/app/shared/example-content.ts
+++ b/apps/examples/src/app/shared/example-content.ts
@@ -1,0 +1,66 @@
+/**
+ * Per-demo documentation convention for the Examples App.
+ *
+ * Every demo page ships a `<demo>.content.ts` file exporting an
+ * {@link ExampleContent} object declared `as const`. The shared
+ * {@link import('../ui/example-cards/example-cards.component').ExampleCardsComponent}
+ * renders it into two side-by-side cards — "What this demonstrates" and
+ * "What you'll learn" — so every page documents itself the same way.
+ *
+ * Longer-form prose lives in a sibling `README.md`; it is repo-discoverable
+ * and intentionally not rendered inside the app shell in this wave.
+ */
+
+/** A titled group of bullet points used in the "What you'll learn" card. */
+export type ExampleLearnSection = {
+  /** Short heading for the group of takeaways. */
+  readonly title: string;
+  /** One concrete takeaway per bullet. */
+  readonly points: readonly string[];
+}
+
+/** Optional pointer to the next recommended demo, rendered as a link. */
+export type ExampleNextStep = {
+  /** Call-to-action label, e.g. "Next: Async validation". */
+  readonly label: string;
+  /** Router path of the next demo, e.g. `'async-username'`. */
+  readonly route: string;
+}
+
+/**
+ * Structured, typed description of what a demo proves and teaches.
+ * Authored once per page in `<demo>.content.ts` and rendered by
+ * `<ngx-example-cards>`.
+ */
+export type ExampleContent = {
+  /** "What this demonstrates" — the capabilities the page exercises. */
+  readonly demonstrates: {
+    /** Single emoji used as the card glyph (decorative). */
+    readonly icon: string;
+    /** Card title, usually "What this demonstrates". */
+    readonly title: string;
+    /** Capability bullets — what the running demo proves. */
+    readonly points: readonly string[];
+  };
+  /** "What you'll learn" — grouped takeaways plus an optional next step. */
+  readonly learn: {
+    /** Card title, usually "What you'll learn". */
+    readonly title: string;
+    /** Grouped learning sections. */
+    readonly sections: readonly ExampleLearnSection[];
+    /** Optional link to the next recommended demo. */
+    readonly nextStep?: ExampleNextStep;
+  };
+}
+
+/**
+ * Identity helper that preserves literal types while asserting the shape.
+ * Use in each `<demo>.content.ts`:
+ *
+ * ```ts
+ * export const starterContent = defineExampleContent({ ... });
+ * ```
+ */
+export function defineExampleContent<T extends ExampleContent>(content: T): T {
+  return content;
+}

--- a/apps/examples/src/app/shared/routes.metadata.ts
+++ b/apps/examples/src/app/shared/routes.metadata.ts
@@ -1,3 +1,4 @@
+import type { Type } from '@angular/core';
 import type { Routes } from '@angular/router';
 
 /**
@@ -46,7 +47,7 @@ export type ExampleRouteMeta = {
   /** Optional nav badge. */
   readonly badge?: ExampleBadge;
   /** Lazy component loader for the router. */
-  readonly loadComponent: () => Promise<unknown>;
+  readonly loadComponent: () => Promise<Type<unknown>>;
 }
 
 /**
@@ -314,7 +315,7 @@ export function toAppRoutes(): Routes {
     },
     ...EXAMPLE_ROUTES.map((route) => ({
       path: route.path,
-      loadComponent: route.loadComponent as () => Promise<never>,
+      loadComponent: route.loadComponent,
       data: { title: route.title, subtitle: route.subtitle },
     })),
     {

--- a/apps/examples/src/app/shared/routes.metadata.ts
+++ b/apps/examples/src/app/shared/routes.metadata.ts
@@ -1,0 +1,325 @@
+import type { Routes } from '@angular/router';
+
+/**
+ * Single source of truth for the Examples App shell.
+ *
+ * Routes, nav labels, category placement, ordering, and page header copy all
+ * live here. The router config ({@link toAppRoutes}) and the categorized nav
+ * ({@link buildNavGroups}) are both derived from {@link EXAMPLE_ROUTES} — so
+ * adding or re-grouping a demo is a data change in this file, never a template
+ * change in the shell.
+ */
+
+/**
+ * Curated taxonomy for ngx-vest-forms — intentionally curated for this
+ * library, not a mirror of any other demo app's taxonomy. Array order is the
+ * order categories appear in the nav.
+ */
+export const EXAMPLE_CATEGORIES = [
+  'Getting Started',
+  'Validation',
+  'Schema',
+  'Composition',
+  'Controls',
+  'Patterns',
+] as const;
+
+export type ExampleCategory = (typeof EXAMPLE_CATEGORIES)[number];
+
+/** Optional nav badge. `start-here` marks the canonical onboarding demo. */
+export type ExampleBadge = 'start-here' | 'new';
+
+/** One demo's placement and metadata in the shell. */
+export type ExampleRouteMeta = {
+  /** Router path segment, e.g. `'starter'`. */
+  readonly path: string;
+  /** Short label shown in the categorized nav. */
+  readonly label: string;
+  /** Page `<h1>` rendered via `ngx-page-title`. */
+  readonly title: string;
+  /** Page subtitle rendered via `ngx-page-title`. */
+  readonly subtitle: string;
+  /** Category bucket in the nav. */
+  readonly category: ExampleCategory;
+  /** Sort order within the category (ascending). */
+  readonly order: number;
+  /** Optional nav badge. */
+  readonly badge?: ExampleBadge;
+  /** Lazy component loader for the router. */
+  readonly loadComponent: () => Promise<unknown>;
+}
+
+/**
+ * The curated demo catalog. Keep it intentionally lean — each entry must earn
+ * its place. New first-wave demos are appended here as they land so the nav,
+ * router, and default route stay in sync from one place.
+ */
+export const EXAMPLE_ROUTES: readonly ExampleRouteMeta[] = [
+  // ── Getting Started ───────────────────────────────────────────────────────
+  {
+    path: 'starter',
+    label: 'Starter Contact Form',
+    title: 'Starter Contact Form',
+    subtitle:
+      'The canonical ngx-vest-forms setup — copy this as a trustworthy baseline.',
+    category: 'Getting Started',
+    order: 1,
+    badge: 'start-here',
+    loadComponent: () =>
+      import('../pages/starter-form/starter.page').then(
+        (m) => m.StarterPageComponent
+      ),
+  },
+
+  // ── Validation ────────────────────────────────────────────────────────────
+  {
+    path: 'validation-config-demo',
+    label: 'Validation Config',
+    title: 'Validation Config Demo',
+    subtitle:
+      'Explore dependency-aware revalidation patterns with a single configuration map.',
+    category: 'Validation',
+    order: 1,
+    loadComponent: () =>
+      import(
+        '../pages/validation-config-demo/validation-config-demo.page'
+      ).then((m) => m.ValidationConfigDemoPageComponent),
+  },
+  {
+    path: 'display-modes-demo',
+    label: 'Display Modes',
+    title: 'Display Modes Demo',
+    subtitle:
+      'Compare error and warning visibility timing across display modes.',
+    category: 'Validation',
+    order: 2,
+    loadComponent: () =>
+      import('../pages/display-modes-demo/display-modes-demo.page').then(
+        (m) => m.DisplayModesDemoPageComponent
+      ),
+  },
+  {
+    path: 'business-hours',
+    label: 'Business Hours',
+    title: 'Business Hours Form',
+    subtitle:
+      'Validate dynamic time ranges with cross-field and form-level rules.',
+    category: 'Validation',
+    order: 3,
+    loadComponent: () =>
+      import('../pages/business-hours-form/business-hours.page').then(
+        (m) => m.BusinessHoursPageComponent
+      ),
+  },
+  {
+    path: 'async-username',
+    label: 'Async Username',
+    title: 'Async Username Availability',
+    subtitle:
+      'Validate a username against a mock remote endpoint with calm pending, success, and failure states.',
+    category: 'Validation',
+    order: 4,
+    badge: 'new',
+    loadComponent: () =>
+      import('../pages/async-username-form/async-username.page').then(
+        (m) => m.AsyncUsernamePageComponent
+      ),
+  },
+  {
+    path: 'business-policy',
+    label: 'Business Policy',
+    title: 'Vest-First Business Policy',
+    subtitle:
+      'Conditional rules and advisory warnings that stay native to Vest — guidance modelled separately from errors.',
+    category: 'Validation',
+    order: 5,
+    badge: 'new',
+    loadComponent: () =>
+      import('../pages/business-policy-form/business-policy.page').then(
+        (m) => m.BusinessPolicyPageComponent
+      ),
+  },
+
+  // ── Schema ────────────────────────────────────────────────────────────────
+  {
+    path: 'native-schema-demo',
+    label: 'Native Vest Schema',
+    title: 'Native Vest Schema Demo',
+    subtitle:
+      'Use create(..., enforce.shape(...)) for built-in schema validation alongside field-level business rules.',
+    category: 'Schema',
+    order: 1,
+    loadComponent: () =>
+      import('../pages/native-schema-demo/native-schema-demo.page').then(
+        (m) => m.NativeSchemaDemoPageComponent
+      ),
+  },
+  {
+    path: 'zod-schema-demo',
+    label: 'Zod Schema',
+    title: 'Zod Schema Demo',
+    subtitle:
+      'Combine a Zod schema alongside Vest per-field business rules in one example flow.',
+    category: 'Schema',
+    order: 2,
+    loadComponent: () =>
+      import('../pages/zod-schema-demo/zod-schema-demo.page').then(
+        (m) => m.ZodSchemaDemoPageComponent
+      ),
+  },
+
+  // ── Composition ───────────────────────────────────────────────────────────
+  {
+    path: 'date-range-adapter',
+    label: 'Composite Adapter',
+    title: 'Composite Adapter Recipe',
+    subtitle:
+      'Map one composite UI control to multiple form fields with split-field validation.',
+    category: 'Composition',
+    order: 1,
+    loadComponent: () =>
+      import('../pages/date-range-adapter/travel.page').then(
+        (m) => m.TravelPageComponent
+      ),
+  },
+  {
+    path: 'complex-nested',
+    label: 'Complex Nested & Repeatable',
+    title: 'Complex Nested & Repeatable Form',
+    subtitle:
+      'Nested ngModelGroup sections and dynamic add/remove rows composed from reusable child components.',
+    category: 'Composition',
+    order: 2,
+    badge: 'new',
+    loadComponent: () =>
+      import('../pages/complex-nested-form/complex-nested.page').then(
+        (m) => m.ComplexNestedPageComponent
+      ),
+  },
+
+  // ── Controls ──────────────────────────────────────────────────────────────
+  {
+    path: 'custom-controls',
+    label: 'Custom Controls',
+    title: 'Custom Controls (ControlValueAccessor)',
+    subtitle:
+      'A non-native control participating in validation, warnings, touched state, and submission.',
+    category: 'Controls',
+    order: 1,
+    badge: 'new',
+    loadComponent: () =>
+      import('../pages/custom-controls-form/custom-controls.page').then(
+        (m) => m.CustomControlsPageComponent
+      ),
+  },
+
+  // ── Patterns ──────────────────────────────────────────────────────────────
+  {
+    path: 'purchase',
+    label: 'Purchase Checkout',
+    title: 'Purchase Form',
+    subtitle:
+      'Complete a full checkout flow with conditional and cross-field validation.',
+    category: 'Patterns',
+    order: 1,
+    loadComponent: () =>
+      import('../pages/purchase-form/purchase.page').then(
+        (m) => m.PurchasePageComponent
+      ),
+  },
+  {
+    path: 'submission-patterns',
+    label: 'Submission Patterns',
+    title: 'Submission Patterns',
+    subtitle:
+      'Submit-time invalid handling, server-error messaging, success state, and retry — modelled distinctly.',
+    category: 'Patterns',
+    order: 2,
+    badge: 'new',
+    loadComponent: () =>
+      import('../pages/submission-patterns-form/submission-patterns.page').then(
+        (m) => m.SubmissionPatternsPageComponent
+      ),
+  },
+  {
+    path: 'auto-save-demo',
+    label: 'Auto-Save Draft',
+    title: 'Auto-Save Draft Demo',
+    subtitle:
+      'Persist draft changes on blur while keeping validation and final submission separate.',
+    category: 'Patterns',
+    order: 3,
+    loadComponent: () =>
+      import('../pages/auto-save-demo/auto-save-demo.page').then(
+        (m) => m.AutoSaveDemoPageComponent
+      ),
+  },
+  {
+    path: 'wizard',
+    label: 'Multi-Form Wizard',
+    title: 'Multi-Form Wizard',
+    subtitle:
+      'Run three coordinated forms with per-step validation and one final submission flow.',
+    category: 'Patterns',
+    order: 4,
+    loadComponent: () =>
+      import('../pages/wizard-form/wizard-form.page').then(
+        (m) => m.WizardFormPageComponent
+      ),
+  },
+];
+
+/** A nav category plus its demos, ready for the shell template. */
+export type NavGroup = {
+  readonly category: ExampleCategory;
+  readonly items: readonly ExampleRouteMeta[];
+}
+
+/** Demos sorted by category order, then by intra-category `order`. */
+function sortedRoutes(): ExampleRouteMeta[] {
+  return [...EXAMPLE_ROUTES].sort((a, b) => {
+    const byCategory =
+      EXAMPLE_CATEGORIES.indexOf(a.category) -
+      EXAMPLE_CATEGORIES.indexOf(b.category);
+    return byCategory !== 0 ? byCategory : a.order - b.order;
+  });
+}
+
+/**
+ * The canonical onboarding demo: the `start-here` badge if present, otherwise
+ * the first demo in catalog order. Drives the app's default redirect.
+ */
+export function defaultRoutePath(): string {
+  const sorted = sortedRoutes();
+  const startHere = sorted.find((route) => route.badge === 'start-here');
+  return startHere?.path ?? sorted[0]?.path ?? '';
+}
+
+/** Build the categorized nav structure consumed by the shell. */
+export function buildNavGroups(): NavGroup[] {
+  const sorted = sortedRoutes();
+  return EXAMPLE_CATEGORIES.map((category) => ({
+    category,
+    items: sorted.filter((route) => route.category === category),
+  })).filter((group) => group.items.length > 0);
+}
+
+/** Map the metadata catalog into Angular router config. */
+export function toAppRoutes(): Routes {
+  return [
+    {
+      path: '',
+      redirectTo: defaultRoutePath(),
+      pathMatch: 'full',
+    },
+    ...EXAMPLE_ROUTES.map((route) => ({
+      path: route.path,
+      loadComponent: route.loadComponent as () => Promise<never>,
+      data: { title: route.title, subtitle: route.subtitle },
+    })),
+    {
+      path: '**',
+      redirectTo: defaultRoutePath(),
+    },
+  ];
+}

--- a/apps/examples/src/app/shared/routes.metadata.ts
+++ b/apps/examples/src/app/shared/routes.metadata.ts
@@ -140,6 +140,20 @@ export const EXAMPLE_ROUTES: readonly ExampleRouteMeta[] = [
         (m) => m.BusinessPolicyPageComponent
       ),
   },
+  {
+    path: 'conditional-structure',
+    label: 'Conditional Structure',
+    title: 'Conditional Structure & Field Clearing',
+    subtitle:
+      'Keep model state and validation aligned when inputs disappear or turn into static content.',
+    category: 'Validation',
+    order: 6,
+    badge: 'new',
+    loadComponent: () =>
+      import(
+        '../pages/conditional-structure-demo/conditional-structure.page'
+      ).then((m) => m.ConditionalStructurePageComponent),
+  },
 
   // ── Schema ────────────────────────────────────────────────────────────────
   {
@@ -211,6 +225,20 @@ export const EXAMPLE_ROUTES: readonly ExampleRouteMeta[] = [
     loadComponent: () =>
       import('../pages/custom-controls-form/custom-controls.page').then(
         (m) => m.CustomControlsPageComponent
+      ),
+  },
+  {
+    path: 'accessible-wrapper',
+    label: 'Accessible Wrapper',
+    title: 'Accessible Custom Wrapper',
+    subtitle:
+      'Use directive-based ARIA wiring when the built-in wrapper markup is not the right fit.',
+    category: 'Controls',
+    order: 2,
+    badge: 'new',
+    loadComponent: () =>
+      import('../pages/accessible-wrapper-demo/accessible-wrapper.page').then(
+        (m) => m.AccessibleWrapperPageComponent
       ),
   },
 

--- a/apps/examples/src/app/ui/example-cards/example-cards.component.ts
+++ b/apps/examples/src/app/ui/example-cards/example-cards.component.ts
@@ -1,0 +1,101 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import type { ExampleContent } from '../../shared/example-content';
+import { Card } from '../card/card.component';
+
+/**
+ * Renders a demo's `<demo>.content.ts` ({@link ExampleContent}) into two
+ * side-by-side cards — "What this demonstrates" and "What you'll learn" — so
+ * every demo documents itself with the same structure and a developer can
+ * judge relevance in seconds without reading the source.
+ *
+ * This is the only genuinely new shared UI component in the shell upgrade; it
+ * composes the existing `ngx-card`.
+ */
+@Component({
+  selector: 'ngx-example-cards',
+  imports: [Card, RouterLink],
+  template: `
+    <div class="grid gap-6 md:grid-cols-2">
+      <ngx-card>
+        <div class="flex items-start gap-3">
+          <span
+            class="bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300 flex size-10 shrink-0 items-center justify-center rounded-lg text-xl"
+            aria-hidden="true"
+            >{{ content().demonstrates.icon }}</span
+          >
+          <div>
+            <h2
+              class="text-base font-semibold text-gray-900 dark:text-white"
+            >
+              {{ content().demonstrates.title }}
+            </h2>
+            <ul
+              class="mt-3 space-y-1.5 text-sm text-gray-600 dark:text-gray-300"
+            >
+              @for (point of content().demonstrates.points; track point) {
+                <li class="flex gap-2">
+                  <span class="text-primary-600 dark:text-primary-400" aria-hidden="true">▸</span>
+                  <span>{{ point }}</span>
+                </li>
+              }
+            </ul>
+          </div>
+        </div>
+      </ngx-card>
+
+      <ngx-card>
+        <div class="flex items-start gap-3">
+          <span
+            class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-amber-100 text-xl text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+            aria-hidden="true"
+            >🎓</span
+          >
+          <div class="min-w-0">
+            <h2
+              class="text-base font-semibold text-gray-900 dark:text-white"
+            >
+              {{ content().learn.title }}
+            </h2>
+            <div class="mt-3 space-y-4">
+              @for (section of content().learn.sections; track section.title) {
+                <div>
+                  <h3
+                    class="text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400"
+                  >
+                    {{ section.title }}
+                  </h3>
+                  <ul
+                    class="mt-1.5 space-y-1.5 text-sm text-gray-600 dark:text-gray-300"
+                  >
+                    @for (point of section.points; track point) {
+                      <li class="flex gap-2">
+                        <span class="text-amber-600 dark:text-amber-400" aria-hidden="true">▸</span>
+                        <span>{{ point }}</span>
+                      </li>
+                    }
+                  </ul>
+                </div>
+              }
+            </div>
+            @if (content().learn.nextStep; as nextStep) {
+              <a
+                [routerLink]="['/', nextStep.route]"
+                class="text-primary-700 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300 mt-4 inline-flex items-center gap-1 text-sm font-medium"
+              >
+                {{ nextStep.label }}
+                <span aria-hidden="true">→</span>
+              </a>
+            }
+          </div>
+        </div>
+      </ngx-card>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: { class: 'block' },
+})
+export class ExampleCardsComponent {
+  /** The page's typed content metadata, authored in `<demo>.content.ts`. */
+  readonly content = input.required<ExampleContent>();
+}

--- a/apps/examples/src/app/ui/form-state/form-state.component.ts
+++ b/apps/examples/src/app/ui/form-state/form-state.component.ts
@@ -4,7 +4,12 @@ import {
   computed,
   input,
 } from '@angular/core';
-import { createEmptyFormState, NgxFormState, ROOT_FORM } from 'ngx-vest-forms';
+import {
+  createEmptyFormState,
+  NgxFormFeedbackSignals,
+  NgxFormState,
+  ROOT_FORM,
+} from 'ngx-vest-forms';
 import { AlertPanel } from '../alert-panel/alert-panel.component';
 import { Card } from '../card/card.component';
 import { JsonPreviewComponent } from '../json-preview/json-preview.component';
@@ -154,11 +159,21 @@ type MessageInput = readonly string[] | Record<string, string[]>;
 export class FormStateCardComponent {
   readonly title = input('Form State');
   readonly formValueTitle = input('Form Value');
+
+  /**
+   * Packaged feedback signals from a form.
+   * If provided, `formState`, `warnings`, `validatedFields`, and `pending` will
+   * fallback to reading from this object.
+   */
+  readonly feedback = input<NgxFormFeedbackSignals<unknown> | null | undefined>(
+    undefined
+  );
+
   readonly formState = input<NgxFormState<unknown> | null>(null);
   readonly isValid = input<boolean | null>(null);
   readonly formValue = input<unknown | null>(null);
   /** True when async validation is currently in progress. */
-  readonly pending = input(false);
+  readonly pending = input<boolean | null>(null);
 
   /** Accepts a flat `string[]` or a `Record<string, string[]>` (flattened internally). */
   readonly errors = input<MessageInput | null>(null);
@@ -196,8 +211,15 @@ export class FormStateCardComponent {
   });
 
   readonly #warningsRecord = computed(() => {
-    const raw = this.#toRecord(this.warnings());
-    return this.#filterByValidatedFields(raw);
+    const explicit = this.warnings();
+    if (explicit !== null) {
+      return this.#filterByValidatedFields(this.#toRecord(explicit));
+    }
+    const feedbackWarnings = this.feedback()?.warnings();
+    if (feedbackWarnings) {
+      return this.#filterByValidatedFields(feedbackWarnings);
+    }
+    return {};
   });
 
   readonly #validationWarningRulesRecord = computed(() =>
@@ -230,7 +252,7 @@ export class FormStateCardComponent {
   // ── Passing: validated fields without visible issues ───────────────
 
   protected readonly resolvedMessages = computed(() => {
-    const validated = new Set(this.validatedFields() ?? []);
+    const validated = new Set(this.resolvedValidatedFields() ?? []);
     if (validated.size === 0) {
       return [];
     }
@@ -251,7 +273,10 @@ export class FormStateCardComponent {
   // ── Display computeds ─────────────────────────────────────────────
 
   protected readonly resolvedFormState = computed(
-    () => this.formState() ?? createEmptyFormState<unknown>()
+    () =>
+      this.formState() ??
+      this.feedback()?.formState() ??
+      createEmptyFormState<unknown>()
   );
 
   protected readonly effectiveIsValid = computed(
@@ -300,10 +325,16 @@ export class FormStateCardComponent {
       this.uniqueWarnings().length > 0
   );
 
-  protected readonly isPending = computed(() => this.pending());
+  protected readonly isPending = computed(
+    () => this.pending() ?? this.feedback()?.pending() ?? false
+  );
+
+  protected readonly resolvedValidatedFields = computed(
+    () => this.validatedFields() ?? this.feedback()?.validatedFields() ?? null
+  );
 
   protected readonly isPristine = computed(() => {
-    const validated = this.validatedFields();
+    const validated = this.resolvedValidatedFields();
     return (
       !this.isPending() &&
       Array.isArray(validated) &&
@@ -343,7 +374,7 @@ export class FormStateCardComponent {
   #filterByValidatedFields(
     record: Record<string, string[]>
   ): Record<string, string[]> {
-    const validatedFieldsList = this.validatedFields();
+    const validatedFieldsList = this.resolvedValidatedFields();
     if (validatedFieldsList === null || validatedFieldsList === undefined) {
       return record;
     }
@@ -376,7 +407,7 @@ export class FormStateCardComponent {
   }
 
   #collectUnusedRules(rules: Record<string, string[]>): string[] {
-    const validated = new Set(this.validatedFields() ?? []);
+    const validated = new Set(this.resolvedValidatedFields() ?? []);
     const messages = Object.entries(rules)
       .filter(([field]) => field === '_flat' || !validated.has(field))
       .flatMap(([field, fieldRules]) => {

--- a/apps/examples/src/main.ts
+++ b/apps/examples/src/main.ts
@@ -2,7 +2,6 @@ import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { bootstrapApplication } from '@angular/platform-browser';
 import {
   provideRouter,
-  Routes,
   withEnabledBlockingInitialNavigation,
 } from '@angular/router';
 import { provideEnvironmentNgxMask } from 'ngx-mask';
@@ -12,129 +11,15 @@ import {
 } from 'ngx-vest-forms';
 import { AppComponent } from './app/app.component';
 import { mockPeopleApiInterceptor } from './app/services/mock-people-api.interceptor';
+import { toAppRoutes } from './app/shared/routes.metadata';
 
-const appRoutes: Routes = [
-  {
-    path: '',
-    redirectTo: 'purchase',
-    pathMatch: 'full',
-  },
-  {
-    path: 'purchase',
-    loadComponent: () =>
-      import('./app/pages/purchase-form/purchase.page').then(
-        (m) => m.PurchasePageComponent
-      ),
-    data: {
-      title: 'Purchase Form',
-      subtitle:
-        'Complete a full checkout flow with conditional and cross-field validation.',
-    },
-  },
-  {
-    path: 'business-hours',
-    loadComponent: () =>
-      import('./app/pages/business-hours-form/business-hours.page').then(
-        (m) => m.BusinessHoursPageComponent
-      ),
-    data: {
-      title: 'Business Hours Form',
-      subtitle:
-        'Validate dynamic time ranges with cross-field and form-level rules.',
-    },
-  },
-  {
-    path: 'validation-config-demo',
-    loadComponent: () =>
-      import('./app/pages/validation-config-demo/validation-config-demo.page').then(
-        (m) => m.ValidationConfigDemoPageComponent
-      ),
-    data: {
-      title: 'Validation Config Demo',
-      subtitle:
-        'Explore dependency-aware revalidation patterns with a configuration map.',
-    },
-  },
-  {
-    path: 'auto-save-demo',
-    loadComponent: () =>
-      import('./app/pages/auto-save-demo/auto-save-demo.page').then(
-        (m) => m.AutoSaveDemoPageComponent
-      ),
-    data: {
-      title: 'Auto-Save Draft Demo',
-      subtitle:
-        'Persist draft changes on blur while keeping validation and final submission separate.',
-    },
-  },
-  {
-    path: 'wizard',
-    loadComponent: () =>
-      import('./app/pages/wizard-form/wizard-form.page').then(
-        (m) => m.WizardFormPageComponent
-      ),
-    data: {
-      title: 'Multi-Form Wizard',
-      subtitle:
-        'Run three coordinated forms with per-step validation and one final submission flow.',
-    },
-  },
-  {
-    path: 'display-modes-demo',
-    loadComponent: () =>
-      import('./app/pages/display-modes-demo/display-modes-demo.page').then(
-        (m) => m.DisplayModesDemoPageComponent
-      ),
-    data: {
-      title: 'Display Modes Demo',
-      subtitle:
-        'Compare error and warning visibility timing across display modes.',
-    },
-  },
-  {
-    path: 'native-schema-demo',
-    loadComponent: () =>
-      import('./app/pages/native-schema-demo/native-schema-demo.page').then(
-        (m) => m.NativeSchemaDemoPageComponent
-      ),
-    data: {
-      title: 'Native Vest Schema Demo',
-      subtitle:
-        'Use create(..., enforce.shape(...)) for built-in schema validation alongside field-level business rules.',
-    },
-  },
-  {
-    path: 'zod-schema-demo',
-    loadComponent: () =>
-      import('./app/pages/zod-schema-demo/zod-schema-demo.page').then(
-        (m) => m.ZodSchemaDemoPageComponent
-      ),
-    data: {
-      title: 'Zod Schema Demo',
-      subtitle:
-        'Combine a Zod schema alongside Vest per-field business rules in one example flow.',
-    },
-  },
-  {
-    path: 'date-range-adapter',
-    loadComponent: () =>
-      import('./app/pages/date-range-adapter/travel.page').then(
-        (m) => m.TravelPageComponent
-      ),
-    data: {
-      title: 'Composite Adapter Recipe',
-      subtitle:
-        'Map one composite UI control to multiple form fields with split-field validation.',
-    },
-  },
-];
 bootstrapApplication(AppComponent, {
   providers: [
     provideHttpClient(withInterceptors([mockPeopleApiInterceptor])),
     provideEnvironmentNgxMask({ validation: false }),
-    provideRouter(appRoutes, withEnabledBlockingInitialNavigation()),
-    // Global configuration for validation config debounce timing
-    // Using 150ms instead of default 100ms to reduce validation frequency during rapid typing
+    provideRouter(toAppRoutes(), withEnabledBlockingInitialNavigation()),
+    // Global configuration for validation config debounce timing.
+    // Using the relaxed preset reduces validation frequency during rapid typing.
     {
       provide: NGX_VALIDATION_CONFIG_DEBOUNCE_TOKEN,
       useValue: NGX_VALIDATION_DEBOUNCE_PRESETS.relaxed,

--- a/apps/examples/src/styles.scss
+++ b/apps/examples/src/styles.scss
@@ -357,3 +357,15 @@ fieldset:not(.form-shell) {
     }
   }
 }
+
+/* Shell nav reveal — staggered per category group via inline animation-delay. */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/packages/ngx-vest-forms/src/lib/components/control-wrapper/control-wrapper.component.css
+++ b/packages/ngx-vest-forms/src/lib/components/control-wrapper/control-wrapper.component.css
@@ -8,6 +8,7 @@
    *   ngx-control-wrapper { --ngx-control-wrapper-error-color: ...; }
    *   html.dark ngx-control-wrapper { --ngx-control-wrapper-error-color: ...; }
    *
+   *   --ngx-control-wrapper-feedback-min-height
    *   --ngx-control-wrapper-message-margin-top
    *   --ngx-control-wrapper-message-font-size
    *   --ngx-control-wrapper-message-line-height
@@ -38,6 +39,7 @@
    */
 
   /* Private defaults — do not override these directly. */
+  --_ngx-control-wrapper-feedback-min-height: 1.25rem; /* By default, reserving enough space for one line of text using --_ngx-control-wrapper-message-line-height */
   --_ngx-control-wrapper-message-margin-top: 0.25rem;
   --_ngx-control-wrapper-message-font-size: 0.875rem;
   --_ngx-control-wrapper-message-line-height: 1.25rem;
@@ -67,12 +69,25 @@
   }
 }
 
-.ngx-control-wrapper__errors,
-.ngx-control-wrapper__warnings {
+.ngx-control-wrapper__feedback-container {
+  display: flex;
+  flex-direction: column;
+  min-height: var(
+    --ngx-control-wrapper-feedback-min-height,
+    var(--_ngx-control-wrapper-feedback-min-height)
+  );
   margin-top: var(
     --ngx-control-wrapper-message-margin-top,
     var(--_ngx-control-wrapper-message-margin-top)
   );
+  gap: var(
+    --ngx-control-wrapper-message-gap,
+    var(--_ngx-control-wrapper-message-gap)
+  );
+}
+
+.ngx-control-wrapper__errors,
+.ngx-control-wrapper__warnings {
   font-size: var(
     --ngx-control-wrapper-message-font-size,
     var(--_ngx-control-wrapper-message-font-size)

--- a/packages/ngx-vest-forms/src/lib/components/control-wrapper/control-wrapper.component.html
+++ b/packages/ngx-vest-forms/src/lib/components/control-wrapper/control-wrapper.component.html
@@ -22,42 +22,44 @@
   @see https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA21 - Using aria-invalid
   @see https://www.w3.org/WAI/WCAG22/Techniques/aria/ARIA22 - Using role=status
 -->
-<div
-  [id]="errorId"
-  class="ngx-control-wrapper__errors"
-  role="status"
-  aria-live="polite"
-  aria-atomic="true"
->
-  @if (errorDisplay.shouldShowErrors()) {
-    <ul class="ngx-control-wrapper__messages">
-      @for (error of errorDisplay.errors(); track error) {
-        <li>{{ error }}</li>
-      }
-    </ul>
-  }
-</div>
+<div class="ngx-control-wrapper__feedback-container">
+  <div
+    [id]="errorId"
+    class="ngx-control-wrapper__errors"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    @if (errorDisplay.shouldShowErrors()) {
+      <ul class="ngx-control-wrapper__messages">
+        @for (error of errorDisplay.errors(); track error) {
+          <li>{{ error }}</li>
+        }
+      </ul>
+    }
+  </div>
 
-<!--
-  Warnings: Non-blocking validation messages (Vest warn())
-  - Use role="status" with aria-live="polite" per WCAG ARIA22
-  - Default: show after validation runs or touch; configurable to require touch only
-  - Warnings do NOT affect field validity - they're informational only
--->
-<div
-  [id]="warningId"
-  class="ngx-control-wrapper__warnings"
-  role="status"
-  aria-live="polite"
-  aria-atomic="true"
->
-  @if (shouldShowWarnings()) {
-    <ul class="ngx-control-wrapper__messages">
-      @for (warn of errorDisplay.warnings(); track warn) {
-        <li>{{ warn }}</li>
-      }
-    </ul>
-  }
+  <!--
+    Warnings: Non-blocking validation messages (Vest warn())
+    - Use role="status" with aria-live="polite" per WCAG ARIA22
+    - Default: show after validation runs or touch; configurable to require touch only
+    - Warnings do NOT affect field validity - they're informational only
+  -->
+  <div
+    [id]="warningId"
+    class="ngx-control-wrapper__warnings"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+  >
+    @if (shouldShowWarnings()) {
+      <ul class="ngx-control-wrapper__messages">
+        @for (warn of errorDisplay.warnings(); track warn) {
+          <li>{{ warn }}</li>
+        }
+      </ul>
+    }
+  </div>
 </div>
 
 <!-- Pending state is also stable; content appears only after the debounce delay -->


### PR DESCRIPTION
The Examples App becomes a curated showcase instead of a flat list of pages. A categorized sidebar replaces the top-nav, every demo documents itself with a consistent two-card summary, and the catalog gains six new first-wave demos covering scenarios the app previously didn't (starter, async, custom controls, submission, complex nested, Vest-first policy). The nine existing pages are migrated into the new shell with no behavior change.

**Metadata-driven shell.** Routes, nav labels, category placement, ordering, badges, and the default route are all derived from one module — `apps/examples/src/app/shared/routes.metadata.ts`. The router config (`toAppRoutes()`) and the categorized nav (`buildNavGroups()`) read from it, so re-grouping or adding a demo is a data change there, never a template change in the shell. Adding a demo now looks like:

```ts
{
  path: 'starter',
  label: 'Starter Contact Form',
  title: 'Starter Contact Form',
  subtitle: 'The canonical ngx-vest-forms setup …',
  category: 'Getting Started',
  order: 1,
  badge: 'start-here',
  loadComponent: () => import('../pages/starter-form/starter.page')
    .then((m) => m.StarterPageComponent),
}
```

**Per-demo documentation convention.** A typed `ExampleContent` contract (`shared/example-content.ts`) plus one new shared component, `ngx-example-cards`, render "What this demonstrates" / "What you'll learn" on every page. Each demo also ships a repo-discoverable `README.md`. This is the only genuinely new shared UI component; existing `card`, `page-title`, `form-page-layout`, and `form-state-card` are reused, not duplicated.

**Six new demos, public API only.** Starter contact form (canonical entry, default route), async username availability, custom controls (three `ControlValueAccessor` components), submission patterns, complex nested & repeatable, and a Vest-first business-policy form. None reach into library internals.

**New mock endpoints.** The in-app HTTP interceptor gains two routes so the app stays self-contained — no backend service:

```
GET  /api/username-availability/:name   -> { username, available }
POST /api/account                        -> 201 { id } | 409 | simulated failure
```

Both honor `?errorScenario=` for deterministic failure paths, matching the existing `/api/people/:id` convention.

The nine existing pages (purchase, wizard, validation-config, auto-save, display-modes, native-schema, zod-schema, composite-adapter, business-hours) were migrated opportunistically: each gained a `.content.ts` + `README.md` + example-cards + categorized placement, with form behavior untouched.

`nx build` and `nx lint` are clean; all 15 routes were exercised in a browser with zero console errors, and the async, starter, and complex-nested behaviors were smoke-tested.

Closes #175