### PR TITLE
docs: Refresh v3 documentation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A lightweight, type-safe adapter between Angular template-driven forms and [Vest.js](https://vestjs.dev) validation. Build complex forms with unidirectional data flow, sophisticated async validations, and minimal boilerplate.
 
 [![npm version](https://img.shields.io/npm/v/ngx-vest-forms.svg?style=flat-square)](https://www.npmjs.com/package/ngx-vest-forms)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/ngx-vest-forms/ngx-vest-forms/cd.yml?branch=master&style=flat-square&label=Build)](https://github.com/ngx-vest-forms/ngx-vest-forms/actions/workflows/cd.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/ngx-vest-forms/ngx-vest-forms/ci.yml?branch=release/v3&style=flat-square&label=Build)](https://github.com/ngx-vest-forms/ngx-vest-forms/actions/workflows/ci.yml)
 [![Angular](<https://img.shields.io/badge/Angular-19+%20(min)%20%E2%80%94%2021%20recommended-dd0031?style=flat-square&logo=angular>)](https://angular.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-blue?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ See the full guides under [Documentation](#documentation).
 
 ### Prerequisites
 
-- **Angular**: >=19.0.0 minimum, 20.x recommended (all used APIs stable)
-- **Vest.js**: >=5.4.6 (Validation engine)
-- **TypeScript**: >=5.8.0 (Modern Angular features)
-- **Node.js**: >=20 (Maintenance release)
+- **Angular**: `>=19.0.0` peer range; the examples and guidance in this repo target Angular 21.x
+- **Vest.js**: `>=6.0.0`; the documentation assumes modern Vest 6 APIs
+- **TypeScript**: `>=5.8.0`; this repo currently uses TypeScript 5.9.x
+- **Node.js**: use an Angular-supported LTS for your app; this repo is developed on Node 22+
 
 ### Installation
 
@@ -45,43 +45,59 @@ See the full guides under [Documentation](#documentation).
 npm install ngx-vest-forms
 ```
 
-> **v.2.0.0 NOTE:**
+> **v3 guidance:**
 >
-> You must call `only()` **unconditionally** in Vest suites.
+> - Write suites with Vest 6's model-only callback: `create((model) => { ... })`
+> - Handle field focus at the call site with `suite.only(field).run(model)`; `ngx-vest-forms` does this internally for field-level validation
+> - Use the `ngx-` selector family; the legacy `sc-` prefix was removed in v3
 >
 > ```ts
-> // ✅ Correct
-> only(field); // only(undefined) safely runs all tests
+> import { create, enforce, test } from 'vest';
+>
+> const suite = create((model) => {
+>   test('email', 'Email is required', () => {
+>     enforce(model.email).isNotBlank();
+>   });
+> });
 > ```
 >
-> Why: Conditional `only()` breaks Vest's change detection mechanism and causes timing issues with `omitWhen` + `validationConfig` in ngx-vest-forms.
-> See the [Migration Guide](./docs/migration/MIGRATION-v1.x-to-v2.0.0.md#1-unconditional-only-pattern-required-critical).
->
-> Selector prefix: use `ngx-`. The legacy `sc-` prefix was removed in v3. See the [selector migration guide](./docs/SELECTOR-PREFIX-MIGRATION.md) if you are upgrading from v2.x.
+> If you're upgrading older code that still uses callback `field?` parameters or `staticSuite(...)`, see the [v2.x → v3 migration guide](./docs/migration/MIGRATION-v2.x-to-v3.0.0.md).
 
 ### Quick Start
 
 Start simple (with validations):
 
 ```ts
-import { Component, signal } from '@angular/core';
-import { NgxVestForms, NgxDeepPartial, NgxVestSuite } from 'ngx-vest-forms';
-import { staticSuite, only, test, enforce } from 'vest';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import {
+  NgxVestForms,
+  type NgxDeepPartial,
+  type NgxVestSuite,
+} from 'ngx-vest-forms';
+import { create, enforce, test } from 'vest';
 
 type MyFormModel = NgxDeepPartial<{ email: string; name: string }>;
 
-// Minimal validation suite (always call only(field) unconditionally)
-const suite: NgxVestSuite<MyFormModel> = staticSuite((model, field?) => {
-  only(field);
+const suite: NgxVestSuite<MyFormModel> = create((model) => {
   test('email', 'Email is required', () => {
     enforce(model.email).isNotBlank();
+  });
+
+  test('name', 'Name is required', () => {
+    enforce(model.name).isNotBlank();
   });
 });
 
 @Component({
+  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgxVestForms],
   template: `
-    <form ngxVestForm [suite]="suite" (formValueChange)="formValue.set($event)">
+    <form
+      ngxVestForm
+      [suite]="suite"
+      [formValue]="formValue()"
+      (formValueChange)="formValue.set($event)"
+    >
       <ngx-control-wrapper>
         <label for="email">Email</label>
         <input id="email" name="email" [ngModel]="formValue().email" />
@@ -103,11 +119,12 @@ export class MyComponent {
 }
 ```
 
-Notes.
+Notes:
 
 - Use `[ngModel]` (not `[(ngModel)]`) for unidirectional data flow
-- The `?` operator is required because template-driven forms build values incrementally (`NgxDeepPartial`)
+- Use optional chaining for nested partial values because template-driven forms build values incrementally (`NgxDeepPartial`)
 - The `name` attribute MUST exactly match the property path used in `[ngModel]` — see [Field Paths](./docs/FIELD-PATHS.md)
+- For field-level validation, ngx-vest-forms drives the Vest 6 suite with `suite.only(field).run(model)` internally
 
 That's all you need. The directive automatically creates controls, wires validation, and manages state.
 
@@ -115,7 +132,7 @@ That's all you need. The directive automatically creates controls, wires validat
 
 - **Unidirectional state with signals** — Models are `NgxDeepPartial<T>` so values build up incrementally
 - **Type-safe with development-time contract diagnostics** — Automatic control creation and validation wiring (dev mode checks)
-- **Vest.js validations** — Sync/async, conditional, composable patterns with `only(field)` optimization
+- **Vest.js validations** — Sync/async, conditional, composable patterns with Vest 6 model-only suites and `only(field)` optimization
 - **Error display modes** — Control when errors show: `on-blur`, `on-submit`, `on-blur-or-submit` (default), `on-dirty`, or `always`
 - **Warning display modes** — Control when warnings show: `on-touch`, `on-validated-or-touch` (default), `on-dirty`, or `always`
 - **Form state tracking** — Access touched, dirty, valid/invalid states for individual fields or entire form
@@ -125,12 +142,13 @@ That's all you need. The directive automatically creates controls, wires validat
   - `FormErrorControlDirective` (adds ARIA wiring + stable region IDs)
 - **Cross-field dependencies** — `validationConfig` for field-to-field triggers, `ROOT_FORM` for form-level rules
 - **Field blur events** — `fieldBlur` output for blur-driven draft auto-save, analytics, and field-level side effects
-- **Utilities** — Field paths, field clearing, validation config builder
+- **Utilities** — Field paths, field clearing, validation config builder, pending-state helpers, and Standard Schema adapters
 
-### Compatibility & Safety Notes (v2.x)
+### v3 cleanup notes
 
-- `ROOT_FORM_CONSTANT` is retained for compatibility but deprecated; prefer `ROOT_FORM`.
-- `set` / `cloneDeep` are retained for compatibility; prefer `setValueAtPath` / `structuredClone` in new code.
+- Legacy v2 aliases such as `ROOT_FORM_CONSTANT`, `set()`, and `cloneDeep()` were removed in v3.
+- Use `ROOT_FORM`, `setValueAtPath()`, and `structuredClone()` in current code.
+- `[formShape]` was replaced by `[formContract]`; raw `NgxDeepRequired<T>` shapes still work for incremental migration.
 
 ### Error & Warning Display Modes
 
@@ -540,7 +558,7 @@ If the contract genuinely varies per usage site, `[formContract]` still works as
 ## Migration
 
 - v1.x → v2.0.0: **[Migration Guide](./docs/migration/MIGRATION-v1.x-to-v2.0.0.md)**
-- v2.x → v3.0.0: **[Selector/Token Removal Guide](./docs/migration/MIGRATION-v2.x-to-v3.0.0.md)**
+- v2.x → v3.0.0: **[Migration Guide](./docs/migration/MIGRATION-v2.x-to-v3.0.0.md)**
 
 ### `[formShape]` → `[formContract]` (v3)
 
@@ -562,7 +580,7 @@ The `[formShape]` input on `<form ngxVestForm>` is replaced by `[formContract]`,
 
 `@standard-schema/spec` is now declared as a `peerDependency` (`>=1.0.0`). Most consumers don't need to install it directly — bring it in only if you author your own `StandardSchemaV1<T>` literals. The internal `validateShape()` helper has been removed; use `toFormContract()` if you need explicit shape→schema conversion.
 
-Browser support follows Angular 19+ targets (no `structuredClone` polyfill required).
+Browser support follows Angular's supported browser targets for the Angular version you run. No `structuredClone` polyfill is required for the Angular-supported environments covered by v3.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A lightweight, type-safe adapter between Angular template-driven forms and [Vest
 
 [![npm version](https://img.shields.io/npm/v/ngx-vest-forms.svg?style=flat-square)](https://www.npmjs.com/package/ngx-vest-forms)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/ngx-vest-forms/ngx-vest-forms/cd.yml?branch=master&style=flat-square&label=Build)](https://github.com/ngx-vest-forms/ngx-vest-forms/actions/workflows/cd.yml)
-[![Angular](<https://img.shields.io/badge/Angular-19+%20(min)%20%E2%80%94%2020%20recommended-dd0031?style=flat-square&logo=angular>)](https://angular.dev)
+[![Angular](<https://img.shields.io/badge/Angular-19+%20(min)%20%E2%80%94%2021%20recommended-dd0031?style=flat-square&logo=angular>)](https://angular.dev)
 [![TypeScript](https://img.shields.io/badge/TypeScript-blue?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 [![License](https://img.shields.io/badge/License-MIT-yellow?style=flat-square)](LICENSE)
 
@@ -48,7 +48,7 @@ npm install ngx-vest-forms
 > **v3 guidance:**
 >
 > - Write suites with Vest 6's model-only callback: `create((model) => { ... })`
-> - Handle field focus at the call site with `suite.only(field).run(model)`; `ngx-vest-forms` does this internally for field-level validation
+> - ngx-vest-forms uses `suite.only(field).run(model)` internally for field-level validation; your suite callback should be model-only
 > - Use the `ngx-` selector family; the legacy `sc-` prefix was removed in v3
 >
 > ```ts
@@ -89,6 +89,7 @@ const suite: NgxVestSuite<MyFormModel> = create((model) => {
 });
 
 @Component({
+  standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgxVestForms],
   template: `

--- a/docs/STRUCTURE_CHANGE_DETECTION.md
+++ b/docs/STRUCTURE_CHANGE_DETECTION.md
@@ -98,7 +98,7 @@ It only re-runs validation logic to update validity state.
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MyFormComponent {
-  // Modern Angular 20+: Use viewChild() instead of @ViewChild
+  // Modern Angular: use viewChild() instead of @ViewChild when available
   private readonly vestForm =
     viewChild.required<FormDirective<MyFormModel>>('vestForm');
 

--- a/docs/VALIDATION-CONFIG-VS-ROOT-FORM.md
+++ b/docs/VALIDATION-CONFIG-VS-ROOT-FORM.md
@@ -410,34 +410,30 @@ export class MyFormComponent {
   protected readonly errors = signal<Record<string, string[]>>({});
 
   // validationConfig: Field dependency timing
-  protected readonly validationConfig = computed(() => {
-    const config: Record<string, string[]> = {};
-    if (this.formValue().type === 'typeA') {
-      config['password'] = ['confirmPassword']; // When password changes, revalidate confirm
-    }
-    return config;
-  });
-
-  protected readonly suite = staticSuite(
-    (model: MyFormModel, field?: string) => {
-      only(field);
-
-      // Field-level validations
-      omitWhen(model.type !== 'typeA', () => {
-        test('password', 'Password required', () => {
-          enforce(model.password).isNotBlank();
-        });
-        test('confirmPassword', 'Passwords must match', () => {
-          enforce(model.confirmPassword).equals(model.password);
-        });
-      });
-
-      // Form-level validation using ROOT_FORM
-      test(ROOT_FORM, 'At least one contact method required', () => {
-        enforce(model.email || model.phone).isTruthy();
-      });
-    }
+  protected readonly validationConfig = computed(() =>
+    this.formValue().type === 'typeA'
+      ? createValidationConfig<MyFormModel>()
+          .whenChanged('password', 'confirmPassword')
+          .build()
+      : {}
   );
+
+  protected readonly suite = create((model: MyFormModel) => {
+    // Field-level validations
+    omitWhen(model.type !== 'typeA', () => {
+      test('password', 'Password required', () => {
+        enforce(model.password).isNotBlank();
+      });
+      test('confirmPassword', 'Passwords must match', () => {
+        enforce(model.confirmPassword).equals(model.password);
+      });
+    });
+
+    // Form-level validation using ROOT_FORM
+    test(ROOT_FORM, 'At least one contact method required', () => {
+      enforce(model.email || model.phone).isTruthy();
+    });
+  });
 
   // triggerFormValidation(): After structure changes
   onTypeChange(type: string) {

--- a/docs/VALIDATION-CONFIG-VS-ROOT-FORM.md
+++ b/docs/VALIDATION-CONFIG-VS-ROOT-FORM.md
@@ -355,6 +355,8 @@ onTypeChange(type: string) {
 
 These features complement each other in complex, dynamic forms:
 
+> **Note:** `createValidationConfig` is exported from `ngx-vest-forms`. Add it to your imports alongside `FormDirective` (e.g. `import { createValidationConfig, FormDirective } from 'ngx-vest-forms';`) before using it in the example below.
+
 ```typescript
 // Component
 @Component({

--- a/docs/VALIDATION-CONFIG-VS-ROOT-FORM.md
+++ b/docs/VALIDATION-CONFIG-VS-ROOT-FORM.md
@@ -415,7 +415,7 @@ export class MyFormComponent {
       ? createValidationConfig<MyFormModel>()
           .whenChanged('password', 'confirmPassword')
           .build()
-      : {}
+      : null
   );
 
   protected readonly suite = create((model: MyFormModel) => {

--- a/docs/VESTJS-SKILL.md
+++ b/docs/VESTJS-SKILL.md
@@ -18,15 +18,15 @@ npx skills add ngx-vest-forms/ngx-vest-forms --skill vestjs
 
 The top-level `vestjs` skill is a **router**. It points the model toward the right focused sub-skill instead of answering every Vest question with one giant catch-all prompt.
 
-It is also the **stable public entry point** for versioning. Right now, that router defaults to the **Vest 5.4 / 5.x** lane used by this repository.
+It is also the **stable public entry point** for versioning. In this repository, that router now defaults to the **Vest 6.x** lane used by `ngx-vest-forms` v3.
 
 ### Core workflow sub-skills
 
 | Sub-skill                  | What it covers                                                                                   |
 | -------------------------- | ------------------------------------------------------------------------------------------------ |
-| `core`                     | first suites, `create` vs `staticSuite`, `test`, `enforce`, `only`, stateful vs stateless design |
-| `conditional-control-flow` | `skip`, `only`, `include`, `skipWhen`, `omitWhen`, `optional`, linked fields, hidden branches    |
-| `async-and-warnings`       | async tests, `AbortSignal`, stale request avoidance, `warn()`, `.done()`, pending state          |
+| `core`                     | first suites, `create`, native schema-aware suites, `test`, `enforce`, `suite.only(...).run(...)`, stateful vs stateless design |
+| `conditional-control-flow` | `skip`, `focus`, `only`, `include`, `skipWhen`, `omitWhen`, `optional`, linked fields, hidden branches |
+| `async-and-warnings`       | async tests, `AbortSignal`, stale request avoidance, `warn()`, `useWarn()`, `afterEach()`, `afterField()`, pending state |
 | `results-groups-and-types` | result access, `group`, `each`, execution modes, typed suites, group-specific result queries     |
 
 ### Advanced workflow sub-skills
@@ -34,14 +34,14 @@ It is also the **stable public entry point** for versioning. Right now, that rou
 | Sub-skill                  | What it covers                                                                               |
 | -------------------------- | -------------------------------------------------------------------------------------------- |
 | `enforce-and-custom-rules` | `enforce.condition`, `enforce.extend`, `compose`, custom rule design, matcher typing         |
-| `server-side-validation`   | request isolation, `staticSuite`, server-oriented execution modes, backend validation output |
+| `server-side-validation`   | request isolation, `runStatic()`, server-oriented execution modes, backend validation output |
 
 ## How it is intended to be used
 
 Use `vestjs` for broad or ambiguous requests like:
 
 - “How should I structure this Vest suite?”
-- “What’s the right 5.x pattern for conditional validation?”
+- “What’s the right Vest 6 pattern for conditional validation?”
 - “Why is this skipped field still making my form invalid?”
 - “How do I type a Vest suite in TypeScript?”
 - “How should I do server-side request validation with Vest?”
@@ -59,20 +59,18 @@ Version-specific material is organized internally so the skill can grow without 
 ### Current internal versioned layout
 
 - `.agents/skills/vestjs/references/version-selection.md`
-- `.agents/skills/vestjs/references/5.x/source-map.md`
-- `.agents/skills/vestjs/evals/5.x.json`
+- `.agents/skills/vestjs/references/5.x/source-map.md` (historical migration reference)
+- `.agents/skills/vestjs/evals/evals.json` (current supported lane)
 
 This means:
 
 - the **public skill stays stable**
-- the **current default lane is 5.x**
-- a future `6.x` lane can be added without forcing users to switch install names immediately
+- the **current default lane is 6.x**
+- historical 5.x material is still available for migration guidance
 
-### When to add a separate 6.x lane
+### Historical 5.x material
 
-Add internal `6.x` references and evals when Vest 6 support is actually needed.
-
-Only consider separate public skills like `vestjs-5x` and `vestjs-6x` if both majors later become actively maintained and materially divergent in practice.
+The repo keeps 5.x source maps and evals for migration work, but current guidance should not present Vest 5 patterns as the default. If you're maintaining legacy code, use that material to explain the migration path rather than teaching callback `field?` parameters, `staticSuite(...)`, or result `.done()` as current practice.
 
 ## Repo alignment
 
@@ -85,14 +83,15 @@ If a question involves both raw Vest behavior and Angular template-driven integr
 - `.agents/skills/vestjs/SKILL.md`
 - `.agents/skills/vestjs/references/version-selection.md`
 - `.agents/skills/vestjs/references/5.x/source-map.md`
+- `.agents/skills/vestjs/evals/evals.json`
 - `.github/instructions/vest.instructions.md`
 - `.agents/skills/ngx-vest-forms/`
 
 ## Upstream references
 
-- [Vest 5.x docs](https://vestjs.dev/docs/5.x/get_started)
-- [Vest 5.x API reference](https://vestjs.dev/docs/5.x/api_reference)
-- [Vest 5.x TypeScript support](https://vestjs.dev/docs/5.x/typescript_support)
+- [Vest docs](https://vestjs.dev/docs/get_started)
+- [Vest API reference](https://vestjs.dev/docs/api_reference)
+- [Vest TypeScript support](https://vestjs.dev/docs/typescript_support)
 
 ## Manual review reminder
 

--- a/docs/VESTJS-SKILL.md
+++ b/docs/VESTJS-SKILL.md
@@ -34,7 +34,7 @@ It is also the **stable public entry point** for versioning. In this repository,
 | Sub-skill                  | What it covers                                                                               |
 | -------------------------- | -------------------------------------------------------------------------------------------- |
 | `enforce-and-custom-rules` | `enforce.condition`, `enforce.extend`, `compose`, custom rule design, matcher typing         |
-| `server-side-validation`   | request isolation, `runStatic()`, server-oriented execution modes, backend validation output |
+| `server-side-validation`   | request isolation, `suite.runStatic(...)`, server-oriented execution modes, backend validation output |
 
 ## How it is intended to be used
 


### PR DESCRIPTION
Align the public documentation entry points with the current release/v3 baseline.

Replace Vest 5 default examples with Vest 6 suite patterns and update compatibility wording so readers are guided toward supported v3 APIs.