### PR TITLE
docs(forms): clarify schema-first formContract guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ If the contract genuinely varies per usage site, `[formContract]` still works as
 
 ### Examples
 
-- **[Examples Project](./apps/examples)** - Working code examples with business hours forms, purchase forms, validation config demos, and blur-driven draft auto-save
+- **[Examples Project](./apps/examples)** - Working code examples with business hours forms, purchase forms, validation config demos, blur-driven draft auto-save, and schema-backed `formContract` demos (Zod + hand-rolled Standard Schema)
   - Run locally: `corepack enable && pnpm install && pnpm start`
   - Includes smart components, UI components, and complete validation patterns
 
@@ -544,19 +544,21 @@ If the contract genuinely varies per usage site, `[formContract]` still works as
 
 ### `[formShape]` → `[formContract]` (v3)
 
-The `[formShape]` input on `<form ngxVestForm>` is replaced by `[formContract]`, which accepts any [Standard Schema v1](https://standardschema.dev) value (Zod v4, Valibot, hand-rolled, …) **or** a legacy `NgxDeepRequired<T>` shape for back-compat:
+The `[formShape]` input on `<form ngxVestForm>` is replaced by `[formContract]`, which accepts any [Standard Schema v1](https://standardschema.dev) value (Zod v4, Valibot, hand-rolled, …) **or** a legacy `NgxDeepRequired<T>` shape for back-compat.
+
+If you already have a schema, pass it directly and keep that as the structural source of truth. Reach for a raw `NgxDeepRequired<T>` shape only as a low-dependency fallback or during incremental migration:
 
 ```html
 <!-- v2 -->
 <form ngxVestForm [suite]="suite" [formShape]="shape"></form>
 
-<!-- v3: legacy shape fallback still works -->
+<!-- v3: shape still works as a migration/fallback path -->
 <form ngxVestForm [suite]="suite" [formContract]="shape"></form>
 
-<!-- v3: explicit conversion to StandardSchemaV1 -->
+<!-- v3: explicit migration from legacy shape to Standard Schema -->
 <form ngxVestForm [suite]="suite" [formContract]="toFormContract(shape)"></form>
 
-<!-- v3: real Standard Schema (recommended for new code) -->
+<!-- v3: real Standard Schema (preferred when your app already has one) -->
 <form ngxVestForm [suite]="suite" [formContract]="zodSchema"></form>
 ```
 

--- a/apps/examples/src/app/models/purchase-form.model.ts
+++ b/apps/examples/src/app/models/purchase-form.model.ts
@@ -26,8 +26,10 @@ export type PurchaseFormModel = NgxDeepPartial<{
   };
 }>;
 
-// Using NgxDeepRequired for the contract (standard approach)
-// Note: birthDate is initialized with a Date object for type safety
+// Low-dependency fallback contract for an example that does not already own a
+// schema. If your app already has a Standard Schema contract, prefer passing
+// that directly to [formContract].
+// Note: birthDate is initialized with a Date object for type safety.
 export const purchaseFormContract: NgxDeepRequired<PurchaseFormModel> = {
   userId: '',
   firstName: '',

--- a/docs/TYPE-COMPATIBILITY.md
+++ b/docs/TYPE-COMPATIBILITY.md
@@ -79,7 +79,7 @@ A repo-wide find-and-replace from `NgxTypedVestSuite` to `NgxVestSuite` is safe.
 
 ## Date field compatibility
 
-When using `Date` fields in deep-partial form models, legacy `NgxDeepRequired<T>` contracts support the common pattern where form controls start with empty strings before a date is selected:
+When using `Date` fields in deep-partial form models, prefer expressing the contract in your Standard Schema if you already have one. For schema-less forms, the legacy `NgxDeepRequired<T>` fallback still supports the common pattern where form controls start with empty strings before a date is selected:
 
 ```typescript
 import { NgxDeepPartial, NgxDeepRequired } from 'ngx-vest-forms';

--- a/docs/migration/MIGRATION-v2.x-to-v3.0.0.md
+++ b/docs/migration/MIGRATION-v2.x-to-v3.0.0.md
@@ -24,21 +24,19 @@ If you only used the recommended `Ngx*` / `NGX_*` names (or the canonical `setVa
 
 The `[formShape]` input on `<form ngxVestForm>` is removed in v3 and replaced by `[formContract]`, which accepts any [Standard Schema v1](https://standardschema.dev) value (Zod v4, Valibot, hand-rolled, …) **or** a legacy `NgxDeepRequired<T>` shape object for back-compat.
 
+If you already have a schema, pass it directly and let that remain your structural contract. Keep raw `NgxDeepRequired<T>` shapes for migration or for apps that want a low-dependency fallback without bringing in a schema library.
+
 ```html
 <!-- v2 -->
 <form ngxVestForm [suite]="suite" [formShape]="myContract"></form>
 
-<!-- v3: raw NgxDeepRequired<T> shape still accepted (back-compat) -->
+<!-- v3: raw NgxDeepRequired<T> shape still accepted (migration/fallback) -->
 <form ngxVestForm [suite]="suite" [formContract]="myContract"></form>
 
-<!-- v3: explicit conversion to StandardSchemaV1 -->
-<form
-  ngxVestForm
-  [suite]="suite"
-  [formContract]="toFormContract(myContract)"
-></form>
+<!-- v3: explicit conversion from legacy shape to Standard Schema -->
+<form ngxVestForm [suite]="suite" [formContract]="toFormContract(myContract)"></form>
 
-<!-- v3: real Standard Schema (recommended for new code) -->
+<!-- v3: real Standard Schema (preferred when your app already has one) -->
 <form ngxVestForm [suite]="suite" [formContract]="zodSchema"></form>
 ```
 


### PR DESCRIPTION
Reposition the [formContract] docs so a real Standard Schema is the recommended structural source of truth, and raw NgxDeepRequired<T> shapes read as a low-dependency migration/fallback path rather than the default. Touches the README, v2-to-v3 migration guide, type-compatibility notes, and the purchase-form example comment.

Refs #176