### PR TITLE
fix(examples): resolve four pre-3.0.0 a11y and performance blockers

### DIFF
--- a/apps/examples-e2e/helpers/form-helpers.ts
+++ b/apps/examples-e2e/helpers/form-helpers.ts
@@ -381,7 +381,7 @@ export async function typeAndBlur(
  * Get form-level (ROOT_FORM) errors
  */
 export async function getFormLevelErrors(page: Page): Promise<Locator> {
-  return page.locator('[role="alert"]').filter({ hasText: /error/i });
+  return page.getByRole('region', { name: /errors/i });
 }
 
 /**

--- a/apps/examples-e2e/helpers/form-helpers.ts
+++ b/apps/examples-e2e/helpers/form-helpers.ts
@@ -378,7 +378,13 @@ export async function typeAndBlur(
 }
 
 /**
- * Get form-level (ROOT_FORM) errors
+ * Get the form-state "Errors" inspector panel.
+ *
+ * Locates the named, non-live errors region rendered by the form-state
+ * sidebar (`role="region"`, accessible name "Errors"). Note: this is the
+ * always-visible inspector — NOT a `role="alert"` panel; genuine
+ * user-action failures (e.g. fetch errors) render separate assertive
+ * alerts and need their own locators.
  */
 export async function getFormLevelErrors(page: Page): Promise<Locator> {
   return page.getByRole('region', { name: /errors/i });

--- a/apps/examples-e2e/pages/accessible-wrapper-demo/accessible-wrapper.form.spec.ts
+++ b/apps/examples-e2e/pages/accessible-wrapper-demo/accessible-wrapper.form.spec.ts
@@ -19,7 +19,7 @@ test.describe('Accessible Wrapper Demo Form', () => {
 
     await page.getByRole('button', { name: /save preferences/i }).click();
 
-    const errorSummary = page.getByRole('alert').filter({
+    const errorSummary = page.getByRole('region', { name: 'Errors' }).filter({
       hasText: /preferred name is required/i,
     });
 

--- a/apps/examples-e2e/pages/async-username-form/async-username.form.spec.ts
+++ b/apps/examples-e2e/pages/async-username-form/async-username.form.spec.ts
@@ -26,7 +26,7 @@ test.describe('Async Username Form', () => {
     await expect(page.getByText(/checking availability/i)).toBeVisible();
     await waitForValidationToSettle(page);
     await expect(
-      page.getByRole('alert').getByText(/username is already taken/i)
+      page.getByRole('region', { name: 'Errors' }).getByText(/username is already taken/i)
     ).toBeVisible();
 
     await typeAndBlur(username, 'ada_lovelace', 0);

--- a/apps/examples-e2e/pages/business-policy-form/business-policy.form.spec.ts
+++ b/apps/examples-e2e/pages/business-policy-form/business-policy.form.spec.ts
@@ -29,10 +29,10 @@ test.describe('Business Policy Form', () => {
 
     await submitButton.click();
     await expect(
-      page.getByRole('alert').filter({ hasText: /errors/i })
+      page.getByRole('region', { name: 'Errors' })
     ).toBeVisible();
     await expect(
-      page.getByRole('alert').getByText(/account type is required/i)
+      page.getByRole('region', { name: 'Errors' }).getByText(/account type is required/i)
     ).toBeVisible();
 
     await accountType.selectOption('business');

--- a/apps/examples-e2e/pages/conditional-structure-demo/conditional-structure.form.spec.ts
+++ b/apps/examples-e2e/pages/conditional-structure-demo/conditional-structure.form.spec.ts
@@ -67,7 +67,7 @@ test.describe('Conditional Structure Demo Form', () => {
     await page.getByRole('button', { name: /save delivery plan/i }).click();
     await waitForValidationToSettle(page);
 
-    const errorSummary = page.getByRole('alert').filter({
+    const errorSummary = page.getByRole('region', { name: 'Errors' }).filter({
       hasText: /delivery email is required/i,
     });
 

--- a/apps/examples-e2e/pages/custom-controls-form/custom-controls.form.spec.ts
+++ b/apps/examples-e2e/pages/custom-controls-form/custom-controls.form.spec.ts
@@ -12,13 +12,13 @@ test.describe('Custom Controls Form', () => {
 
     await submitButton.click();
     await expect(
-      page.getByRole('alert').getByText(/pick a rating/i)
+      page.getByRole('region', { name: 'Errors' }).getByText(/pick a rating/i)
     ).toBeVisible();
     await expect(
-      page.getByRole('alert').getByText(/select your experience level/i)
+      page.getByRole('region', { name: 'Errors' }).getByText(/select your experience level/i)
     ).toBeVisible();
     await expect(
-      page.getByRole('alert').getByText(/add at least one tag/i)
+      page.getByRole('region', { name: 'Errors' }).getByText(/add at least one tag/i)
     ).toBeVisible();
 
     await page.getByRole('radio', { name: /5 stars/i }).click();

--- a/apps/examples-e2e/pages/starter-form/starter.form.spec.ts
+++ b/apps/examples-e2e/pages/starter-form/starter.form.spec.ts
@@ -13,7 +13,7 @@ test.describe('Starter Form', () => {
     await page.getByRole('button', { name: /send message/i }).click();
     await waitForValidationToSettle(page);
 
-    const errorSummary = page.getByRole('alert').filter({
+    const errorSummary = page.getByRole('region', { name: 'Errors' }).filter({
       hasText: /name is required/i,
     });
 

--- a/apps/examples-e2e/pages/submission-patterns-form/submission-patterns.form.spec.ts
+++ b/apps/examples-e2e/pages/submission-patterns-form/submission-patterns.form.spec.ts
@@ -20,10 +20,10 @@ test.describe('Submission Patterns Form', () => {
 
     await expect(fullName).toBeFocused();
     await expect(
-      page.getByRole('alert').filter({ hasText: /errors/i })
+      page.getByRole('region', { name: 'Errors' })
     ).toBeVisible();
     await expect(
-      page.getByRole('alert').getByText(/full name is required/i)
+      page.getByRole('region', { name: 'Errors' }).getByText(/full name is required/i)
     ).toBeVisible();
   });
 
@@ -38,7 +38,7 @@ test.describe('Submission Patterns Form', () => {
     const clearSubmittedState = page.getByRole('button', {
       name: /clear submitted state/i,
     });
-    const errorSummary = page.getByRole('alert').filter({
+    const errorSummary = page.getByRole('region', { name: 'Errors' }).filter({
       hasText: /email is required/i,
     });
 

--- a/apps/examples/src/app/app.component.html
+++ b/apps/examples/src/app/app.component.html
@@ -93,6 +93,7 @@
             @for (item of group.items; track item.path) {
               <li>
                 <a
+                  data-nav-link
                   routerLinkActive
                   #rla="routerLinkActive"
                   [routerLink]="['/', item.path]"

--- a/apps/examples/src/app/app.component.ts
+++ b/apps/examples/src/app/app.component.ts
@@ -124,9 +124,13 @@ export class AppComponent {
         return;
       }
       if (open && !this.wasOpen) {
-        this.sidebar()
-          ?.nativeElement.querySelector<HTMLElement>('a[routerLink]')
-          ?.focus();
+        // `[routerLink]` is a property binding, so it leaves no attribute in
+        // the rendered DOM — query the static `data-nav-link` marker instead,
+        // falling back to the drawer itself (it has tabindex="-1").
+        const drawer = this.sidebar()?.nativeElement;
+        const firstNavLink =
+          drawer?.querySelector<HTMLElement>('a[data-nav-link]');
+        (firstNavLink ?? drawer)?.focus();
       } else if (!open && this.wasOpen) {
         this.menuToggle()?.nativeElement.focus();
       }

--- a/apps/examples/src/app/pages/business-hours-form/ui/business-hours/business-hours.component.html
+++ b/apps/examples/src/app/pages/business-hours-form/ui/business-hours/business-hours.component.html
@@ -32,7 +32,20 @@
             [title]="'Remove business hour slot ' + (+item.key + 1)"
             [attr.aria-label]="'Remove business hour slot ' + (+item.key + 1)"
           >
-            <i class="fa-solid fa-trash" aria-hidden="true"></i>
+            <svg
+              class="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              aria-hidden="true"
+            >
+              <path
+                d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6h14M10 11v6M14 11v6"
+              />
+            </svg>
           </button>
         </div>
       </fieldset>
@@ -74,10 +87,18 @@
         (click)="addBusinessHour(group, valuesGroup)"
         class="business-hours-add-btn"
       >
-        <i
-          class="fa-solid fa-plus business-hours-add-btn-icon"
+        <svg
+          class="business-hours-add-btn-icon h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          stroke-linecap="round"
+          stroke-linejoin="round"
           aria-hidden="true"
-        ></i>
+        >
+          <path d="M12 5v14M5 12h14" />
+        </svg>
         Add
       </button>
     </div>

--- a/apps/examples/src/app/pages/purchase-form/purchase.form.html
+++ b/apps/examples/src/app/pages/purchase-form/purchase.form.html
@@ -67,7 +67,12 @@
     <ngx-form-section title="Personal Information" tone="neutral">
       <div class="form-stack">
         @if (fetchErrorNotice(); as fetchError) {
-        <ngx-alert-panel tone="error" [title]="fetchError.title">
+        <!-- Async fetch failure in response to a user action: assertive is appropriate. -->
+        <ngx-alert-panel
+          tone="error"
+          [title]="fetchError.title"
+          live="assertive"
+        >
           <div class="space-y-1">
             <p>{{ fetchError.message }}</p>
             @if (fetchError.detail) {

--- a/apps/examples/src/app/pages/purchase-form/purchase.page.html
+++ b/apps/examples/src/app/pages/purchase-form/purchase.page.html
@@ -98,7 +98,8 @@
 
     <section class="space-y-6">
       @if (rootFormErrors().length > 0) {
-      <ngx-alert-panel tone="error" title="Form Errors">
+      <!-- Root-form errors after submit are submission-blocking: assertive is appropriate. -->
+      <ngx-alert-panel tone="error" title="Form Errors" live="assertive">
         <ul class="list-disc space-y-1 pl-5">
           @for (error of rootFormErrors(); track error) {
           <li>{{ error }}</li>

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.html
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.html
@@ -74,7 +74,12 @@
         </button>
       </ngx-alert-panel>
       } @if (state() === 'server-error') {
-      <ngx-alert-panel tone="error" title="Couldn't create your account">
+      <!-- Genuine submission failure from the server: assertive is appropriate. -->
+      <ngx-alert-panel
+        tone="error"
+        title="Couldn't create your account"
+        live="assertive"
+      >
         <p>{{ serverError() }}</p>
         <button type="button" class="btn btn-primary mt-3" (click)="retry()">
           Retry

--- a/apps/examples/src/app/pages/wizard-form/wizard-form.page.html
+++ b/apps/examples/src/app/pages/wizard-form/wizard-form.page.html
@@ -85,7 +85,10 @@
       />
 
       @if (submitError()) {
-      <ngx-alert-panel tone="error">{{ submitError() }}</ngx-alert-panel>
+      <!-- Genuine submission-blocking failure: assertive role="alert" is appropriate here. -->
+      <ngx-alert-panel tone="error" live="assertive">{{
+        submitError()
+      }}</ngx-alert-panel>
       }
 
       <ngx-card>

--- a/apps/examples/src/app/ui/alert-panel/alert-panel.component.ts
+++ b/apps/examples/src/app/ui/alert-panel/alert-panel.component.ts
@@ -1,6 +1,17 @@
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 
 type AlertTone = 'error' | 'warning' | 'info' | 'success';
+
+/**
+ * Live-region behavior of the panel.
+ *
+ * Matches the library's documented contract (see the control-wrapper
+ * template docs): field-level and informational feedback is `polite`;
+ * `assertive` (`role="alert"`) is reserved for submission-blocking
+ * form-level errors. Use `off` for always-visible inspector panels whose
+ * content duplicates what field wrappers already announce.
+ */
+type AlertLive = 'polite' | 'assertive' | 'off';
 
 @Component({
   selector: 'ngx-alert-panel',
@@ -31,9 +42,9 @@ type AlertTone = 'error' | 'warning' | 'info' | 'success';
       [class.dark:border-green-800]="tone() === 'success'"
       [class.dark:bg-green-900/30]="tone() === 'success'"
       [class.dark:text-green-300]="tone() === 'success'"
-      [attr.role]="tone() === 'error' ? 'alert' : 'status'"
-      [attr.aria-live]="tone() === 'error' ? 'assertive' : 'polite'"
-      aria-atomic="true"
+      [attr.role]="role()"
+      [attr.aria-live]="ariaLive()"
+      [attr.aria-atomic]="live() === 'off' ? null : true"
     >
       @if (title()) {
         <h2 class="mb-2 text-sm font-semibold">{{ title() }}</h2>
@@ -50,4 +61,26 @@ type AlertTone = 'error' | 'warning' | 'info' | 'success';
 export class AlertPanel {
   readonly tone = input<AlertTone>('info');
   readonly title = input<string>();
+
+  /**
+   * Live-region politeness. Defaults to `polite` (`role="status"`).
+   * Set to `assertive` only for genuine submission-blocking alerts, or
+   * `off` to render with no live semantics at all.
+   */
+  readonly live = input<AlertLive>('polite');
+
+  protected readonly role = computed(() => {
+    switch (this.live()) {
+      case 'assertive':
+        return 'alert';
+      case 'polite':
+        return 'status';
+      default:
+        return null;
+    }
+  });
+
+  protected readonly ariaLive = computed(() =>
+    this.live() === 'off' ? null : this.live()
+  );
 }

--- a/apps/examples/src/app/ui/alert-panel/alert-panel.component.ts
+++ b/apps/examples/src/app/ui/alert-panel/alert-panel.component.ts
@@ -45,6 +45,7 @@ type AlertLive = 'polite' | 'assertive' | 'off';
       [attr.role]="role()"
       [attr.aria-live]="ariaLive()"
       [attr.aria-atomic]="live() === 'off' ? null : true"
+      [attr.aria-label]="title() || null"
     >
       @if (title()) {
         <h2 class="mb-2 text-sm font-semibold">{{ title() }}</h2>

--- a/apps/examples/src/app/ui/form-state/form-state.component.ts
+++ b/apps/examples/src/app/ui/form-state/form-state.component.ts
@@ -38,10 +38,17 @@ type MessageInput = readonly string[] | Record<string, string[]>;
         </div>
       </div>
 
+      <!--
+        Inspector panels are rendered with live="off": they re-filter on
+        every validation pass and duplicate what the field-level wrappers
+        already announce politely. Announcing them (let alone assertively)
+        would interrupt screen-reader users with the full aggregated list
+        after every blur.
+      -->
       @if (hasMessages()) {
         <div class="mb-4 space-y-2">
           @if (resolvedMessages().length > 0) {
-            <ngx-alert-panel tone="success" [title]="resolvedTitle()">
+            <ngx-alert-panel live="off" tone="success" [title]="resolvedTitle()">
               <ul class="list-disc space-y-1 pl-5">
                 @for (message of resolvedMessages(); track message) {
                   <li>{{ message }}</li>
@@ -51,7 +58,7 @@ type MessageInput = readonly string[] | Record<string, string[]>;
           }
 
           @if (uniqueErrors().length > 0) {
-            <ngx-alert-panel tone="error" [title]="errorsTitle()">
+            <ngx-alert-panel live="off" tone="error" [title]="errorsTitle()">
               <ul class="list-disc space-y-1 pl-5">
                 @for (message of uniqueErrors(); track message) {
                   <li>{{ message }}</li>
@@ -61,7 +68,7 @@ type MessageInput = readonly string[] | Record<string, string[]>;
           }
 
           @if (uniqueWarnings().length > 0) {
-            <ngx-alert-panel tone="warning" [title]="warningsTitle()">
+            <ngx-alert-panel live="off" tone="warning" [title]="warningsTitle()">
               <ul class="list-disc space-y-1 pl-5">
                 @for (message of uniqueWarnings(); track message) {
                   <li>{{ message }}</li>
@@ -71,7 +78,7 @@ type MessageInput = readonly string[] | Record<string, string[]>;
           }
 
           @if (uniqueInfo().length > 0) {
-            <ngx-alert-panel tone="info" [title]="infoTitle()">
+            <ngx-alert-panel live="off" tone="info" [title]="infoTitle()">
               <ul class="list-disc space-y-1 pl-5">
                 @for (message of uniqueInfo(); track message) {
                   <li>{{ message }}</li>
@@ -102,7 +109,7 @@ type MessageInput = readonly string[] | Record<string, string[]>;
         <div
           class="mt-4 border-t border-gray-200/80 pt-4 dark:border-gray-700/80"
         >
-          <ngx-alert-panel tone="info" [title]="validationRulesTitle()">
+          <ngx-alert-panel live="off" tone="info" [title]="validationRulesTitle()">
             @if (unusedValidationWarningRules().length > 0) {
               <div class="space-y-3">
                 @if (unusedValidationErrorRules().length > 0) {

--- a/apps/examples/src/index.html
+++ b/apps/examples/src/index.html
@@ -6,13 +6,6 @@
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-      integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
     <script>
       // Initialize theme before page loads to prevent FOUC
       if (

--- a/apps/examples/src/styles.scss
+++ b/apps/examples/src/styles.scss
@@ -57,6 +57,43 @@
   }
 }
 
+/*
+ * Bridge the library's theming tokens to the app's class-based dark mode.
+ *
+ * The library wrappers switch their default error/warning colors via
+ * `prefers-color-scheme` only, while this app toggles dark mode with a
+ * `.dark` class on <html>. Without this bridge a user whose OS scheme
+ * differs from the app theme gets error text with ~3:1 contrast. All pairs
+ * below meet WCAG 2.2 AA (>= 4.5:1) on the surfaces they render on:
+ *   light: #dc2626 (red-600)  — 4.83:1 on white, 4.62:1 on gray-50
+ *          #b45309 (amber-700) — 5.02:1 on white, 4.81:1 on gray-50
+ *   dark:  #fca5a5 (red-300)  — 7.73:1 on gray-800, 5.43:1 on gray-700
+ *          #fcd34d (amber-300) — 10.18:1 on gray-800, 7.15:1 on gray-700
+ */
+ngx-control-wrapper,
+[ngxControlWrapper] {
+  --ngx-control-wrapper-error-color: #dc2626;
+  --ngx-control-wrapper-warning-color: #b45309;
+}
+
+ngx-form-group-wrapper,
+[ngxFormGroupWrapper] {
+  --ngx-form-group-wrapper-error-color: #dc2626;
+  --ngx-form-group-wrapper-warning-color: #b45309;
+}
+
+html.dark ngx-control-wrapper,
+html.dark [ngxControlWrapper] {
+  --ngx-control-wrapper-error-color: #fca5a5;
+  --ngx-control-wrapper-warning-color: #fcd34d;
+}
+
+html.dark ngx-form-group-wrapper,
+html.dark [ngxFormGroupWrapper] {
+  --ngx-form-group-wrapper-error-color: #fca5a5;
+  --ngx-form-group-wrapper-warning-color: #fcd34d;
+}
+
 @layer components {
   .page-container {
     margin-left: auto;
@@ -96,7 +133,7 @@
 
     /* Apply error styling when aria-invalid is true */
     &[aria-invalid='true'] {
-      @apply border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-500 dark:bg-gray-700 dark:text-red-500 dark:placeholder-red-500;
+      @apply border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-500 dark:bg-gray-700 dark:text-red-300 dark:placeholder-red-300;
     }
 
     /* Disabled state styling */
@@ -106,7 +143,7 @@
   }
 
   .input-field-error {
-    @apply border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-500 dark:bg-gray-700 dark:text-red-500 dark:placeholder-red-500;
+    @apply border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-500 dark:bg-gray-700 dark:text-red-300 dark:placeholder-red-300;
   }
 
   .btn {
@@ -122,7 +159,7 @@
   }
 
   .btn-danger {
-    @apply border border-red-300 bg-white text-red-700 hover:bg-red-50 focus:ring-red-200 dark:border-red-600 dark:bg-gray-800 dark:text-red-500 dark:hover:border-red-500 dark:hover:bg-gray-700 dark:focus:ring-red-900;
+    @apply border border-red-300 bg-white text-red-700 hover:bg-red-50 focus:ring-red-200 dark:border-red-600 dark:bg-gray-800 dark:text-red-300 dark:hover:border-red-500 dark:hover:bg-gray-700 dark:focus:ring-red-900;
   }
 
   .btn-success {
@@ -142,7 +179,7 @@
   }
 
   .error-message {
-    @apply mt-1 text-sm text-red-600 dark:text-red-500;
+    @apply mt-1 text-sm text-red-600 dark:text-red-300;
   }
 
   .form-field,
@@ -339,7 +376,7 @@ fieldset:not(.form-shell) {
 
     &--invalid {
       label span {
-        @apply text-red-600 dark:text-red-500;
+        @apply text-red-600 dark:text-red-300;
       }
 
       select,
@@ -348,12 +385,12 @@ fieldset:not(.form-shell) {
       input[type='password'],
       input[type='date'],
       textarea {
-        @apply border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-500 dark:bg-gray-700 dark:text-red-500 dark:placeholder-red-500;
+        @apply border-red-500 bg-red-50 text-red-900 placeholder-red-700 focus:border-red-500 focus:ring-red-500 dark:border-red-500 dark:bg-gray-700 dark:text-red-300 dark:placeholder-red-300;
       }
     }
 
     &__errors {
-      @apply mt-1 text-sm text-red-600 dark:text-red-500;
+      @apply mt-1 text-sm text-red-600 dark:text-red-300;
     }
   }
 }


### PR DESCRIPTION
## Overview

Resolves the four **examples-app** publish-blockers from the pre-3.0.0 audit fleet (triage #210, fix ticket #211, audit report #213). Closes #211 together with the already-merged #220.

## Fixes

| ID | Fix | Commits |
|----|-----|---------|
| E-B1 | **Dark-mode error contrast now meets WCAG AA.** The app's class-based `.dark` theme now bridges the library's `--ngx-control-wrapper-*` tokens (which key off `prefers-color-scheme`) for both wrapper selectors, and the failing `dark:text-red-500` styles are replaced. All shipped pairs computed ≥ 4.5:1 (e.g. dark error text 5.43–9.35:1, previously 2.74–3.90:1). | `861bcd42` |
| E-B2 | **Form-state error inspector no longer screams at screen readers.** Dropped `role="alert"` + `aria-live="assertive"` + `aria-atomic` from the always-visible inspector panel (it re-announced the full error list on every field validation); it is now a named, queryable region. Genuine user-action failures (purchase fetch error, submission server failure) keep explicit assertive alerts. | `2d6301c3`, `bc54e74a` |
| E-B3 | **Mobile drawer focus management actually works.** The `querySelector('a[routerLink]')` lookup never matched (property binding leaves no attribute); replaced with a `data-nav-link` marker + fallback to the drawer's `tabindex="-1"` container. | `db755ce0` |
| E-B4 | **Font Awesome CDN removed.** The render-blocking stylesheet served two icons; replaced with inline SVG (decorative icons `aria-hidden`, icon-only button properly labelled). No new dependencies. | `9f4c4af2` |

Plus `55ede30a` (test): 8 e2e specs located the inspector via `getByRole('alert')` — i.e. they encoded the exact anti-pattern E-B2 removes; they now use `getByRole('region', { name: 'Errors' })`.

## Verification

- `pnpm nx build examples` — pass · `pnpm nx lint examples` + e2e lint — pass · `pnpm nx test examples` — 21/21
- Playwright e2e, full suite on final code: **webkit 245 passed / 0 failed**. Chromium/firefox runs on the fix machine were disrupted by Playwright browser-binary GC (environmental launch errors, not test failures) — this PR's CI provides the clean 3-browser verification.

Part of the v3.0.0 release map #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
