### PR TITLE
fix(examples): teach the built-in submit focus, settle-then-submit, and public display API

### DIFF
--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.content.ts
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.content.ts
@@ -8,6 +8,7 @@ export const accessibleWrapperContent = defineExampleContent({
       'FormErrorControlDirective gives custom wrappers the same error/warning/pending IDs and ARIA helpers as the built-in wrappers.',
       'ariaAssociationMode="single-control" merges generated error IDs into one existing aria-describedby chain automatically.',
       'ariaAssociationMode="none" lets multi-control wrappers opt out of automatic stamping and wire the relevant input manually.',
+      'ngxErrorControl composes the public FormErrorDisplayDirective, so templates read shouldShowErrors()/errors() through the ngxErrorDisplay export instead of directive internals.',
       'Inline error regions stay in the DOM with stable IDs, so manual aria-describedby wiring remains predictable.',
     ],
   },
@@ -18,6 +19,7 @@ export const accessibleWrapperContent = defineExampleContent({
         title: 'Directive-based wrapper ergonomics',
         points: [
           'Use ngxErrorControl when you need custom markup but still want packaged state and generated region IDs.',
+          'Grab the composed display state with #display="ngxErrorDisplay" — it is the same public API the built-in wrappers use.',
           'Pick ariaAssociationMode based on how many actual form controls live inside the wrapper.',
           'Keep hints in aria-describedby and let the directive merge its own IDs when appropriate.',
         ],

--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.form.html
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.form.html
@@ -7,9 +7,16 @@
   (ngSubmit)="onSubmit()"
   class="space-y-6"
 >
+  <!--
+    ngxErrorControl composes the public FormErrorDisplayDirective, so its
+    display state (shouldShowErrors/errors/warnings/isPending) is available
+    on the same element via the `ngxErrorDisplay` export — no need to reach
+    into the directive's internals.
+  -->
   <div
     ngxErrorControl
     #preferredControl="ngxErrorControl"
+    #preferredDisplay="ngxErrorDisplay"
     ariaAssociationMode="single-control"
     class="rounded-2xl border border-gray-200 bg-white p-4 shadow-xs dark:border-gray-700 dark:bg-gray-900"
   >
@@ -38,8 +45,8 @@
       aria-atomic="true"
       class="mt-3 text-sm text-red-700 dark:text-red-300"
     >
-      @if (shouldShowErrors(preferredControl)) { @for (message of
-      controlErrors(preferredControl); track message) {
+      @if (preferredDisplay.shouldShowErrors()) { @for (message of
+      preferredDisplay.errors(); track message) {
       <p>{{ message }}</p>
       } }
     </div>
@@ -48,6 +55,7 @@
   <div
     ngxErrorControl
     #searchControl="ngxErrorControl"
+    #searchDisplay="ngxErrorDisplay"
     ariaAssociationMode="none"
     class="rounded-2xl border border-gray-200 bg-white p-4 shadow-xs dark:border-gray-700 dark:bg-gray-900"
   >
@@ -67,7 +75,7 @@
         name="searchQuery"
         [ngModel]="formValue().searchQuery"
         [attr.aria-describedby]="'search-query-hint ' + searchControl.errorId"
-        [attr.aria-invalid]="shouldShowErrors(searchControl) ? 'true' : null"
+        [attr.aria-invalid]="searchDisplay.shouldShowErrors() ? 'true' : null"
         autocomplete="off"
         placeholder="Search examples, docs, or issues"
       />
@@ -86,8 +94,8 @@
       aria-atomic="true"
       class="mt-3 text-sm text-red-700 dark:text-red-300"
     >
-      @if (shouldShowErrors(searchControl)) { @for (message of
-      controlErrors(searchControl); track message) {
+      @if (searchDisplay.shouldShowErrors()) { @for (message of
+      searchDisplay.errors(); track message) {
       <p>{{ message }}</p>
       } }
     </div>

--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.form.ts
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.form.ts
@@ -39,19 +39,7 @@ export class AccessibleWrapperFormBody {
     this.resetRequested.emit();
   }
 
-  protected shouldShowErrors(control: FormErrorControlDirective): boolean {
-    return control['errorDisplay'].shouldShowErrors();
-  }
-
-  protected controlErrors(control: FormErrorControlDirective): string[] {
-    return control['errorDisplay'].errors();
-  }
-
   resetFormState(value: AccessibleWrapperModel): void {
     this.vestForm()?.resetForm(value);
-  }
-
-  focusFirstInvalidControl(): void {
-    this.vestForm()?.focusFirstInvalidControl();
   }
 }

--- a/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.page.ts
+++ b/apps/examples/src/app/pages/accessible-wrapper-demo/accessible-wrapper.page.ts
@@ -46,8 +46,9 @@ export class AccessibleWrapperPageComponent {
 
   protected onSubmit(): void {
     if (!this.feedback()?.formState()?.valid) {
+      // The directive focuses the first invalid control on submit by default
+      // (`focusFirstInvalidOnSubmit`), so no manual focus handling is needed.
       this.submittedValue.set(null);
-      this.formBody()?.focusFirstInvalidControl();
       return;
     }
 

--- a/apps/examples/src/app/pages/async-username-form/async-username.content.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.content.ts
@@ -10,6 +10,7 @@ export const asyncUsernameContent = defineExampleContent({
       'vest/memo keying the async test on the username so it only re-runs when the value changes',
       'Aborting the in-flight request through the Vest-provided AbortSignal when the user keeps typing',
       'Pending state surfaced calmly inline and kept separate from submission state',
+      'Submits that land while the check is in flight wait for validation to settle instead of being dropped',
     ],
   },
   learn: {
@@ -27,6 +28,7 @@ export const asyncUsernameContent = defineExampleContent({
         title: 'Surfacing async UI state',
         points: [
           'Reading pending from createFormFeedbackSignals to show a polite "Checking…" hint',
+          'Waiting for pending() to settle on submit so a mid-flight check never swallows the submission',
           'Deriving a success hint from validated fields plus an empty error list',
           'Keeping the suite a plain Vest spec — the service is injected via a factory',
         ],

--- a/apps/examples/src/app/pages/async-username-form/async-username.form.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.form.ts
@@ -60,8 +60,4 @@ export class AsyncUsernameFormBody {
   resetFormState(value: AsyncUsernameModel): void {
     this.vestForm()?.resetForm(value);
   }
-
-  focusFirstInvalidControl(): void {
-    this.vestForm()?.focusFirstInvalidControl();
-  }
 }

--- a/apps/examples/src/app/pages/async-username-form/async-username.page.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.page.ts
@@ -13,7 +13,10 @@ import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
 import { Card } from '../../ui/card/card.component';
 import { ExampleCardsComponent } from '../../ui/example-cards/example-cards.component';
 import { FormStateCardComponent } from '../../ui/form-state/form-state.component';
-import { IntroItemComponent, IntroSectionComponent } from '../../ui/intro-section';
+import {
+  IntroItemComponent,
+  IntroSectionComponent,
+} from '../../ui/intro-section';
 import { PageTitle } from '../../ui/page-title/page-title.component';
 import { asyncUsernameContent } from './async-username.content';
 import { AsyncUsernameFormBody } from './async-username.form';
@@ -68,20 +71,33 @@ export class AsyncUsernamePageComponent {
     computed(() => this.feedback()?.pending() ?? false)
   ).pipe(filter((pending) => !pending));
 
+  /** In-flight guard: one queued submit at a time while validation settles. */
+  private readonly submitting = signal(false);
+
   protected onSubmit(): void {
     // The availability check may still be in flight when the user submits.
     // Mirror the directive's own submit pipeline: wait until async validation
     // settles, then decide — a PENDING form is not an invalid form, and the
-    // submission must never be dropped silently. Focus handling stays with
-    // the directive (`focusFirstInvalidOnSubmit` defaults to true).
+    // submission must never be dropped silently. The `submitting` guard keeps
+    // repeated clicks during the pending window from stacking subscriptions
+    // and double-submitting. Focus handling stays with the directive
+    // (`focusFirstInvalidOnSubmit` defaults to true).
+    if (this.submitting()) {
+      return;
+    }
+    this.submitting.set(true);
     this.validationSettled$
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
-        if (!this.feedback()?.formState()?.valid) {
-          this.submittedValue.set(null);
-          return;
+        try {
+          if (!this.feedback()?.formState()?.valid) {
+            this.submittedValue.set(null);
+            return;
+          }
+          this.submittedValue.set(structuredClone(this.formValue()));
+        } finally {
+          this.submitting.set(false);
         }
-        this.submittedValue.set(structuredClone(this.formValue()));
       });
   }
 

--- a/apps/examples/src/app/pages/async-username-form/async-username.page.ts
+++ b/apps/examples/src/app/pages/async-username-form/async-username.page.ts
@@ -1,10 +1,13 @@
 import {
   Component,
   computed,
+  DestroyRef,
   inject,
   signal,
   viewChild,
 } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { filter, take } from 'rxjs';
 import { AsyncUsernameModel } from '../../models/async-username.model';
 import { AlertPanel } from '../../ui/alert-panel/alert-panel.component';
 import { Card } from '../../ui/card/card.component';
@@ -44,6 +47,7 @@ import { UsernameAvailabilityService } from './username-availability.service';
   templateUrl: './async-username.page.html',
 })
 export class AsyncUsernamePageComponent {
+  private readonly destroyRef = inject(DestroyRef);
   protected readonly exampleContent = asyncUsernameContent;
 
   /** Suite is built in the component so the async service can be injected. */
@@ -59,13 +63,26 @@ export class AsyncUsernamePageComponent {
 
   protected readonly feedback = computed(() => this.formBody()?.feedback);
 
+  /** Emits whenever async validation is idle (not `PENDING`). */
+  private readonly validationSettled$ = toObservable(
+    computed(() => this.feedback()?.pending() ?? false)
+  ).pipe(filter((pending) => !pending));
+
   protected onSubmit(): void {
-    if (!this.feedback()?.formState()?.valid) {
-      this.submittedValue.set(null);
-      this.formBody()?.focusFirstInvalidControl();
-      return;
-    }
-    this.submittedValue.set(structuredClone(this.formValue()));
+    // The availability check may still be in flight when the user submits.
+    // Mirror the directive's own submit pipeline: wait until async validation
+    // settles, then decide — a PENDING form is not an invalid form, and the
+    // submission must never be dropped silently. Focus handling stays with
+    // the directive (`focusFirstInvalidOnSubmit` defaults to true).
+    this.validationSettled$
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        if (!this.feedback()?.formState()?.valid) {
+          this.submittedValue.set(null);
+          return;
+        }
+        this.submittedValue.set(structuredClone(this.formValue()));
+      });
   }
 
   protected reset(): void {

--- a/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.form.ts
+++ b/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.form.ts
@@ -46,10 +46,6 @@ export class ConditionalStructureFormBody {
     this.vestForm()?.resetForm(value);
   }
 
-  focusFirstInvalidControl(): void {
-    this.vestForm()?.focusFirstInvalidControl();
-  }
-
   triggerValidation(): void {
     this.vestForm()?.triggerFormValidation();
   }

--- a/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.page.ts
+++ b/apps/examples/src/app/pages/conditional-structure-demo/conditional-structure.page.ts
@@ -89,8 +89,9 @@ export class ConditionalStructurePageComponent {
 
   protected onSubmit(): void {
     if (!this.feedback()?.formState()?.valid) {
+      // The directive focuses the first invalid control on submit by default
+      // (`focusFirstInvalidOnSubmit`), so no manual focus handling is needed.
       this.submittedPayload.set(null);
-      this.formBody()?.focusFirstInvalidControl();
       return;
     }
 

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.form.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.form.ts
@@ -53,8 +53,4 @@ export class CustomControlsFormBody {
   resetFormState(value: CustomControlsModel): void {
     this.vestForm()?.resetForm(value);
   }
-
-  focusFirstInvalidControl(): void {
-    this.vestForm()?.focusFirstInvalidControl();
-  }
 }

--- a/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.ts
+++ b/apps/examples/src/app/pages/custom-controls-form/custom-controls.page.ts
@@ -49,8 +49,9 @@ export class CustomControlsPageComponent {
 
   protected onSubmit(): void {
     if (!this.feedback()?.formState()?.valid) {
+      // The directive focuses the first invalid control on submit by default
+      // (`focusFirstInvalidOnSubmit`), so no manual focus handling is needed.
       this.submittedValue.set(null);
-      this.formBody()?.focusFirstInvalidControl();
       return;
     }
     this.submittedValue.set(structuredClone(this.formValue()));

--- a/apps/examples/src/app/pages/purchase-form/purchase.content.ts
+++ b/apps/examples/src/app/pages/purchase-form/purchase.content.ts
@@ -11,7 +11,8 @@ export const purchaseContent = defineExampleContent({
       'Conditional validation with omitWhen: emergency contact under 18, "other" gender detail, justification when quantity exceeds 5, shipping address only when it differs from billing',
       'A ROOT_FORM rule ("Brecht is not 30 anymore") proving form-level validation across multiple fields',
       'Non-blocking password-strength warnings via warn() shown alongside blocking errors',
-      'Imperative form helpers: clearFields() to wipe sensitive data, setValueAtPath() to prefill the billing address, and focusFirstInvalidControl() on submit',
+      'Imperative form helpers: clearFields() to wipe sensitive data and setValueAtPath() to prefill the billing address',
+      'A submit gate built on the public feedback signals: it waits for pending() to settle before deciding, while the directive focuses the first invalid control automatically (focusFirstInvalidOnSubmit)',
       'httpResource-driven "Fetch Luke" data load with Zod-backed response parsing and selectable failure scenarios (404, 401, 500, network) that clear fetched fields on error',
     ],
   },
@@ -39,7 +40,7 @@ export const purchaseContent = defineExampleContent({
         points: [
           'clearFields() to reset nested groups like passwords without rebuilding the model',
           'setValueAtPath() to write deep paths such as addresses.billingAddress.street',
-          'focusFirstInvalidControl() to drive accessible submit-time navigation',
+          'Waiting for pending() from createFormFeedbackSignals to settle before deciding a submit — the directive handles invalid-submit focus for you',
         ],
       },
     ],

--- a/apps/examples/src/app/pages/purchase-form/purchase.form.ts
+++ b/apps/examples/src/app/pages/purchase-form/purchase.form.ts
@@ -1,19 +1,18 @@
 import { HttpErrorResponse, httpResource } from '@angular/common/http';
 import {
-  afterNextRender,
   Component,
   computed,
   effect,
   DestroyRef,
   inject,
-  Injector,
   linkedSignal,
   output,
   signal,
   untracked,
   viewChild,
 } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { filter, take } from 'rxjs';
 
 import {
   clearFields,
@@ -96,7 +95,6 @@ export class PurchaseForm {
   protected readonly userIdValidationOptions: ValidationOptions = {
     debounceTime: this.validationDebouncePresets.async,
   };
-  private readonly injector = inject(Injector);
   private readonly destroyRef = inject(DestroyRef);
   private readonly swapiService = inject(SwapiService);
   private readonly productService = inject(ProductService);
@@ -105,6 +103,11 @@ export class PurchaseForm {
   private readonly vestForm =
     viewChild<FormDirective<PurchaseFormModel>>('vestForm');
   readonly feedback = createFormFeedbackSignals(this.vestForm);
+
+  /** Emits whenever async validation is idle (not `PENDING`). */
+  private readonly validationSettled$ = toObservable(
+    this.feedback.pending
+  ).pipe(filter((pending) => !pending));
 
   protected readonly formValue = signal<PurchaseFormModel>(
     initialPurchaseFormValue
@@ -386,26 +389,21 @@ export class PurchaseForm {
   }
 
   protected onSubmit(): void {
-    const formDirective = this.vestForm();
-    if (!formDirective) {
-      return;
-    }
-
-    afterNextRender(
-      () => {
-        formDirective.focusFirstInvalidControl();
-
-        if (
-          !formDirective.ngForm.form.valid ||
-          formDirective.ngForm.form.pending
-        ) {
+    // The userId availability check (and the submit-mode ROOT_FORM rule) may
+    // still be validating when the user hits Submit. Mirror the directive's
+    // own submit pipeline: wait until async validation settles, then decide
+    // via the public feedback signals — never drop the submission silently.
+    // Focus handling stays with the directive: `focusFirstInvalidOnSubmit`
+    // (default true) already moves focus to the first invalid control.
+    this.validationSettled$
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        if (!this.feedback.formState().valid) {
           return;
         }
 
         this.saveRequested.emit(this.formValue());
-      },
-      { injector: this.injector }
-    );
+      });
   }
 
   protected onReset(): void {

--- a/apps/examples/src/app/pages/purchase-form/purchase.form.ts
+++ b/apps/examples/src/app/pages/purchase-form/purchase.form.ts
@@ -2,8 +2,8 @@ import { HttpErrorResponse, httpResource } from '@angular/common/http';
 import {
   Component,
   computed,
-  effect,
   DestroyRef,
+  effect,
   inject,
   linkedSignal,
   output,
@@ -388,21 +388,34 @@ export class PurchaseForm {
     }));
   }
 
+  /** In-flight guard: one queued submit at a time while validation settles. */
+  private readonly submitting = signal(false);
+
   protected onSubmit(): void {
     // The userId availability check (and the submit-mode ROOT_FORM rule) may
     // still be validating when the user hits Submit. Mirror the directive's
     // own submit pipeline: wait until async validation settles, then decide
     // via the public feedback signals — never drop the submission silently.
+    // The `submitting` guard keeps repeated clicks during the pending window
+    // from stacking subscriptions and double-emitting `saveRequested`.
     // Focus handling stays with the directive: `focusFirstInvalidOnSubmit`
     // (default true) already moves focus to the first invalid control.
+    if (this.submitting()) {
+      return;
+    }
+    this.submitting.set(true);
     this.validationSettled$
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
-        if (!this.feedback.formState().valid) {
-          return;
-        }
+        try {
+          if (!this.feedback.formState().valid) {
+            return;
+          }
 
-        this.saveRequested.emit(this.formValue());
+          this.saveRequested.emit(this.formValue());
+        } finally {
+          this.submitting.set(false);
+        }
       });
   }
 

--- a/apps/examples/src/app/pages/purchase-form/purchase.page.html
+++ b/apps/examples/src/app/pages/purchase-form/purchase.page.html
@@ -17,8 +17,8 @@
           <li><strong>clearFields()</strong> utility</li>
           <li><strong>setValueAtPath()</strong> utility</li>
           <li>
-            <strong>focusFirstInvalidControl()</strong> for submit-time invalid
-            navigation
+            Automatic submit-time focus of the first invalid control
+            (<strong>focusFirstInvalidOnSubmit</strong>, default on)
           </li>
           <li>Conditional logic based on First Name (Brecht/Luke)</li>
           <li>Async validation (User ID)</li>

--- a/apps/examples/src/app/pages/starter-form/starter.form.ts
+++ b/apps/examples/src/app/pages/starter-form/starter.form.ts
@@ -45,8 +45,4 @@ export class StarterFormBody {
   resetFormState(value: StarterFormModel): void {
     this.vestForm()?.resetForm(value);
   }
-
-  focusFirstInvalidControl(): void {
-    this.vestForm()?.focusFirstInvalidControl();
-  }
 }

--- a/apps/examples/src/app/pages/starter-form/starter.page.ts
+++ b/apps/examples/src/app/pages/starter-form/starter.page.ts
@@ -50,8 +50,9 @@ export class StarterPageComponent {
 
   protected onSubmit(): void {
     if (!this.feedback()?.formState()?.valid) {
+      // The directive focuses the first invalid control on submit by default
+      // (`focusFirstInvalidOnSubmit`), so no manual focus handling is needed.
       this.submittedValue.set(null);
-      this.formBody()?.focusFirstInvalidControl();
       return;
     }
     this.submittedValue.set(structuredClone(this.formValue()));

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.content.ts
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.content.ts
@@ -6,7 +6,7 @@ export const submissionPatternsContent = defineExampleContent({
     title: 'What this demonstrates',
     points: [
       'Concern (a) — field validation: a plain Vest suite (required, email format, password length, accepted terms) with submit-gated visibility for this demo',
-      'Concern (b) — submit-time INVALID handling: an invalid submit never calls the server and moves focus to the first invalid control',
+      'Concern (b) — submit-time INVALID handling: an invalid submit never calls the server and moves focus to the first invalid control; the form binds [focusFirstInvalidOnSubmit]="false" to opt out of the built-in focus and run its own submit flow',
       'Concern (b.1) — end the submit cycle with clearSubmittedState() so submit-only errors hide without resetting values or Angular control metadata',
       'Concern (c) — server FAILURE messaging: HTTP errors surface in an assertive error panel with a Retry button',
       'Concern (d) — SUCCESS state: a polite success panel echoes the new account id with a "Create another" reset',
@@ -21,7 +21,7 @@ export const submissionPatternsContent = defineExampleContent({
         title: 'Why the four concerns are separate',
         points: [
           'Field validity is decided by the Vest suite; the server is only contacted once the form is valid',
-          'focusFirstInvalidControl() on FormDirective guides keyboard and AT users after an invalid submit',
+          'By default the directive focuses the first invalid control on submit (focusFirstInvalidOnSubmit); set it to false when your page owns the submit flow and call focusFirstInvalidControl() yourself',
           'clearSubmittedState() ends the submit gate without wiping the current values or touched history',
           'Server failure is page state, not validation state — it never pollutes the Vest suite',
         ],

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.form.html
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.form.html
@@ -1,8 +1,14 @@
+<!--
+  [focusFirstInvalidOnSubmit]="false" opts out of the directive's built-in
+  invalid-submit focus: this demo owns the whole submit flow, so the page
+  calls focusFirstInvalidControl() itself after updating its own state.
+-->
 <form
   ngxVestForm
   #vestForm="ngxVestForm"
   [suite]="suite()"
   [formValue]="formValue()"
+  [focusFirstInvalidOnSubmit]="false"
   (formValueChange)="formValueChange.emit($event)"
   (ngSubmit)="onSubmit()"
   class="space-y-6"

--- a/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.ts
+++ b/apps/examples/src/app/pages/submission-patterns-form/submission-patterns.page.ts
@@ -36,7 +36,10 @@ type SubmissionState = 'editing' | 'submitting' | 'server-error' | 'success';
  *
  * (a) field validation — the plain Vest suite;
  * (b) submit-time INVALID handling — never calls the server and moves focus
- *     to the first invalid control via `FormDirective.focusFirstInvalidControl()`;
+ *     to the first invalid control via `FormDirective.focusFirstInvalidControl()`.
+ *     The form opts out of the directive's built-in behavior with
+ *     `[focusFirstInvalidOnSubmit]="false"` so this page fully owns the
+ *     submit flow (state updates first, then focus);
  * (c) server FAILURE messaging — an assertive error panel + Retry;
  * (d) SUCCESS state — a polite success panel + "Create another".
  *

--- a/apps/examples/src/app/pages/wizard-form/wizard-form.content.ts
+++ b/apps/examples/src/app/pages/wizard-form/wizard-form.content.ts
@@ -12,7 +12,7 @@ export const wizardContent = defineExampleContent({
       'Step 2 conditional validation: newsletterFrequency is only required when subscribeNewsletter is on (config rebuilt reactively via computed).',
       'Step 3 optional field: comments is optional() but must pass length validation when provided.',
       'Each step exposes isValid()/validatedFields()/pending() so the parent can drive navigation and focus.',
-      'Invalid-submit focus management, including custom NgxFirstInvalidOptions on Step 2.',
+      'Page-owned invalid-submit focus: each step opts out of the built-in focus via [focusFirstInvalidOnSubmit]="false" because the wizard routes to the first invalid step before focusing, with custom NgxFirstInvalidOptions on Step 2.',
       'Step data and validity persist while navigating back and forth.',
     ],
   },
@@ -40,6 +40,7 @@ export const wizardContent = defineExampleContent({
         points: [
           'Validate the current step on Next, the whole wizard on final submit.',
           'Route to the first invalid step and focus its first invalid control.',
+          'Set [focusFirstInvalidOnSubmit]="false" when the page owns focus — otherwise the directive already focuses the first invalid control on submit.',
           'Pass NgxFirstInvalidOptions to tune scroll/focus behavior per step.',
         ],
       },

--- a/apps/examples/src/app/pages/wizard-form/wizard-step1.form.html
+++ b/apps/examples/src/app/pages/wizard-form/wizard-step1.form.html
@@ -1,9 +1,15 @@
+<!--
+  The wizard page owns focus (it routes to the first invalid STEP before
+  focusing a control), so the built-in invalid-submit focus is disabled via
+  [focusFirstInvalidOnSubmit]="false".
+-->
 <form
   #step1Form="ngxVestForm"
   ngxVestForm
   [suite]="suite()"
   [formValue]="data()"
   [validationConfig]="validationConfig()"
+  [focusFirstInvalidOnSubmit]="false"
   (formValueChange)="dataChange.emit($event)"
   (validChange)="validChange.emit($event)"
   (errorsChange)="errorsChange.emit($event)"

--- a/apps/examples/src/app/pages/wizard-form/wizard-step2.form.html
+++ b/apps/examples/src/app/pages/wizard-form/wizard-step2.form.html
@@ -1,9 +1,16 @@
+<!--
+  The wizard page owns focus (it routes to the first invalid STEP before
+  focusing a control, with custom NgxFirstInvalidOptions on this step), so
+  the built-in invalid-submit focus is disabled via
+  [focusFirstInvalidOnSubmit]="false".
+-->
 <form
   #step2Form="ngxVestForm"
   ngxVestForm
   [suite]="suite()"
   [formValue]="data()"
   [validationConfig]="validationConfig()"
+  [focusFirstInvalidOnSubmit]="false"
   (formValueChange)="dataChange.emit($event)"
   (validChange)="validChange.emit($event)"
   (errorsChange)="errorsChange.emit($event)"

--- a/apps/examples/src/app/pages/wizard-form/wizard-step3.form.html
+++ b/apps/examples/src/app/pages/wizard-form/wizard-step3.form.html
@@ -1,8 +1,14 @@
+<!--
+  The wizard page owns focus (it routes to the first invalid STEP before
+  focusing a control), so the built-in invalid-submit focus is disabled via
+  [focusFirstInvalidOnSubmit]="false".
+-->
 <form
   #step3Form="ngxVestForm"
   ngxVestForm
   [suite]="suite()"
   [formValue]="data()"
+  [focusFirstInvalidOnSubmit]="false"
   (formValueChange)="dataChange.emit($event)"
   (validChange)="validChange.emit($event)"
   (errorsChange)="errorsChange.emit($event)"


### PR DESCRIPTION
## Overview

Resolves #223 — the three examples-app idiom defects from the reference-implementation audit (map #205). **Stacked on #221** (branched from it; also merges current `release/v3` to pick up #220's `focusFirstInvalidOnSubmit`). When #221 merges, GitHub retargets this PR to `release/v3` and the diff reduces to the three fixes below.

## Fixes

1. **Stop duplicating the directive's built-in submit focus** (`00144191`). Eight demos manually called `focusFirstInvalidControl()` on invalid submit — redundant since #220's default-on `focusFirstInvalidOnSubmit`. Plain invalid-submit sites (starter, async-username, custom-controls, accessible-wrapper, conditional-structure, purchase) now rely on the built-in. **Submission-patterns and the wizard instead bind `[focusFirstInvalidOnSubmit]="false"` and keep their custom focus flows** — turning the previously-unshowcased opt-out input into a taught feature (doc panels updated).
2. **Wait for pending validation instead of dropping submits** (`7d64b94b`). The purchase and async-username submit gates read internal `ngForm.form.valid/pending` and silently returned while async validation was in flight — the async demo itself taught a submission-drop. Both now use only public API: `toObservable(pending).pipe(filter(p => !p), take(1))` → decide via `formState().valid`, mirroring the directive's own wait-for-settle pipeline. Content panels teach the pattern.
3. **Read wrapper display state via the `ngxErrorDisplay` export** (`0718566f`). The accessible-wrapper demo string-indexed a `protected` member (`control['errorDisplay']`). Now uses the public `FormErrorDisplayDirective` export (`#display="ngxErrorDisplay"`) and its public `shouldShowErrors`/`errors` signals; bracket-hack helpers deleted.

## Verification

- `pnpm nx build examples` / `lint` — pass · `pnpm nx test examples` — 21/21
- Playwright chromium on all 8 touched pages: **102 passed, 0 failed** (1 pre-existing skip); all `toBeFocused` assertions pass under the new focus split

Part of the v3.0.0 release map #205. Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
